### PR TITLE
[semver:minor] Implement Deletion Threshold Checks for Users and Groups

### DIFF
--- a/internal/sync.go
+++ b/internal/sync.go
@@ -18,7 +18,6 @@ package internal
 import (
 	"context"
 	"errors"
-	"fmt"
 	"io/ioutil"
 
 	"github.com/awslabs/ssosync/internal/aws"
@@ -26,37 +25,39 @@ import (
 	"github.com/awslabs/ssosync/internal/google"
 	"github.com/hashicorp/go-retryablehttp"
 
+	aws_sdk "github.com/aws/aws-sdk-go/aws"
+	aws_sdk_sess "github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/identitystore"
+	"github.com/aws/aws-sdk-go/service/identitystore/identitystoreiface"
 	log "github.com/sirupsen/logrus"
 	admin "google.golang.org/api/admin/directory/v1"
 )
-
-// Aiasing log.Fields to Fields as the `log` package get shadowed by locally
-// assignment to the `log` variable
-type Fields = log.Fields
 
 // SyncGSuite is the interface for synchronizing users/groups
 type SyncGSuite interface {
 	SyncUsers(string) error
 	SyncGroups(string) error
-	SyncGroupsUsers(string) error
+	SyncGroupsUsers(string, string) error
 }
 
 // SyncGSuite is an object type that will synchronize real users and groups
 type syncGSuite struct {
-	aws    aws.Client
-	google google.Client
-	cfg    *config.Config
+	aws                 aws.Client
+	google              google.Client
+	cfg                 *config.Config
+	identityStoreClient identitystoreiface.IdentityStoreAPI
 
 	users map[string]*aws.User
 }
 
 // New will create a new SyncGSuite object
-func New(cfg *config.Config, a aws.Client, g google.Client) SyncGSuite {
+func New(cfg *config.Config, a aws.Client, g google.Client, ids identitystoreiface.IdentityStoreAPI) SyncGSuite {
 	return &syncGSuite{
-		aws:    a,
-		google: g,
-		cfg:    cfg,
-		users:  make(map[string]*aws.User),
+		aws:                 a,
+		google:              g,
+		cfg:                 cfg,
+		identityStoreClient: ids,
+		users:               make(map[string]*aws.User),
 	}
 }
 
@@ -64,14 +65,13 @@ func New(cfg *config.Config, a aws.Client, g google.Client) SyncGSuite {
 // References:
 // * https://developers.google.com/admin-sdk/directory/v1/guides/search-users
 // query possible values:
-// ” --> empty or not defined
-//
-//	name:'Jane'
-//	email:admin*
-//	isAdmin=true
-//	manager='janesmith@example.com'
-//	orgName=Engineering orgTitle:Manager
-//	EmploymentData.projects:'GeneGnomes'
+// '' --> empty or not defined
+//  name:'Jane'
+//  email:admin*
+//  isAdmin=true
+//  manager='janesmith@example.com'
+//  orgName=Engineering orgTitle:Manager
+//  EmploymentData.projects:'GeneGnomes'
 func (s *syncGSuite) SyncUsers(query string) error {
 	log.Debug("get deleted users")
 	deletedUsers, err := s.google.GetDeletedUsers()
@@ -79,10 +79,12 @@ func (s *syncGSuite) SyncUsers(query string) error {
 		log.Warn("Error Getting Deleted Users")
 		return err
 	}
+
 	for _, u := range deletedUsers {
 		log.WithFields(log.Fields{
 			"email": u.PrimaryEmail,
 		}).Info("deleting google user")
+
 		uu, err := s.aws.FindUserByEmail(u.PrimaryEmail)
 		if err != aws.ErrUserNotFound && err != nil {
 			log.WithFields(log.Fields{
@@ -90,57 +92,44 @@ func (s *syncGSuite) SyncUsers(query string) error {
 			}).Warn("Error deleting google user")
 			return err
 		}
+
 		if err == aws.ErrUserNotFound {
 			log.WithFields(log.Fields{
 				"email": u.PrimaryEmail,
 			}).Debug("User already deleted")
 			continue
 		}
-		log.WithFields(log.Fields{
-			"email":    u.PrimaryEmail,
-			"username": uu.Username,
-			"id":       uu.ID,
-		}).Info("Deleting user in AWS")
-		if err := s.aws.DeleteUser(uu); err != nil {
+		_, err = s.identityStoreClient.DeleteUser(&identitystore.DeleteUserInput{IdentityStoreId: &s.cfg.IdentityStoreID, UserId: &uu.ID})
+		if err != nil {
 			log.WithFields(log.Fields{
-				"email":    u.PrimaryEmail,
-				"username": uu.Username,
-				"id":       uu.ID,
+				"email": u.PrimaryEmail,
 			}).Warn("Error deleting user")
 			return err
 		}
-		log.WithFields(log.Fields{
-			"email":    u.PrimaryEmail,
-			"username": uu.Username,
-			"id":       uu.ID,
-		}).Info("User deleted successfully in AWS")
 	}
+
 	log.Debug("get active google users")
 	googleUsers, err := s.google.GetUsers(query)
 	if err != nil {
-		log.WithField("query", query).Warn("Error getting active Google users")
 		return err
 	}
-	log.WithField("count", len(googleUsers)).Info("Active Google users retrieved")
+
 	for _, u := range googleUsers {
 		if s.ignoreUser(u.PrimaryEmail) {
-			log.WithField("email", u.PrimaryEmail).Debug("Ignoring user based on configuration")
 			continue
 		}
+
 		ll := log.WithFields(log.Fields{
 			"email": u.PrimaryEmail,
 		})
+
 		ll.Debug("finding user")
 		uu, _ := s.aws.FindUserByEmail(u.PrimaryEmail)
 		if uu != nil {
 			s.users[uu.Username] = uu
 			// Update the user when suspended state is changed
 			if uu.Active == u.Suspended {
-				log.WithFields(log.Fields{
-					"email":    u.PrimaryEmail,
-					"username": uu.Username,
-					"id":       uu.ID,
-				}).Info("Mismatch active/suspended, updating user")
+				log.Debug("Mismatch active/suspended, updating user")
 				// create new user object and update the user
 				_, err := s.aws.UpdateUser(aws.UpdateUser(
 					uu.ID,
@@ -149,49 +138,25 @@ func (s *syncGSuite) SyncUsers(query string) error {
 					u.PrimaryEmail,
 					!u.Suspended))
 				if err != nil {
-					log.WithFields(log.Fields{
-						"email":    u.PrimaryEmail,
-						"username": uu.Username,
-						"id":       uu.ID,
-					}).Warn("Error updating user")
 					return err
 				}
-				log.WithFields(log.Fields{
-					"email":    u.PrimaryEmail,
-					"username": uu.Username,
-					"id":       uu.ID,
-				}).Info("User updated successfully")
 			}
 			continue
 		}
+
 		ll.Info("creating user")
-		log.WithFields(log.Fields{
-			"email":      u.PrimaryEmail,
-			"givenName":  u.Name.GivenName,
-			"familyName": u.Name.FamilyName,
-			"suspended":  u.Suspended,
-		}).Info("Creating user in AWS")
 		uu, err := s.aws.CreateUser(aws.NewUser(
 			u.Name.GivenName,
 			u.Name.FamilyName,
 			u.PrimaryEmail,
 			!u.Suspended))
 		if err != nil {
-			log.WithFields(log.Fields{
-				"email":      u.PrimaryEmail,
-				"givenName":  u.Name.GivenName,
-				"familyName": u.Name.FamilyName,
-				"suspended":  u.Suspended,
-			}).Warn("Error creating user")
 			return err
 		}
-		log.WithFields(log.Fields{
-			"email":    uu.Username,
-			"username": uu.Username,
-			"id":       uu.ID,
-		}).Info("User created successfully in AWS")
+
 		s.users[uu.Username] = uu
 	}
+
 	return nil
 }
 
@@ -199,123 +164,104 @@ func (s *syncGSuite) SyncUsers(query string) error {
 // References:
 // * https://developers.google.com/admin-sdk/directory/v1/guides/search-groups
 // query possible values:
-// ” --> empty or not defined
-//
-//	name='contact'
-//	email:admin*
-//	memberKey=user@company.com
-//	name:contact* email:contact*
-//	name:Admin* email:aws-*
-//	email:aws-*
+// '' --> empty or not defined
+//  name='contact'
+//  email:admin*
+//  memberKey=user@company.com
+//  name:contact* email:contact*
+//  name:Admin* email:aws-*
+//  email:aws-*
 func (s *syncGSuite) SyncGroups(query string) error {
+
 	log.WithField("query", query).Debug("get google groups")
 	googleGroups, err := s.google.GetGroups(query)
 	if err != nil {
-		log.WithField("query", query).Warn("Error getting Google groups")
 		return err
 	}
-	log.WithField("count", len(googleGroups)).Info("Google groups retrieved")
+
 	correlatedGroups := make(map[string]*aws.Group)
+
 	for _, g := range googleGroups {
 		if s.ignoreGroup(g.Email) || !s.includeGroup(g.Email) {
-			log.WithField("group", g.Email).Debug("Ignoring group based on configuration")
 			continue
 		}
+
 		log := log.WithFields(log.Fields{
 			"group": g.Email,
 		})
+
 		log.Debug("Check group")
 		var group *aws.Group
+
 		gg, err := s.aws.FindGroupByDisplayName(g.Email)
 		if err != nil && err != aws.ErrGroupNotFound {
-			log.WithField("group", g.Email).Warn("Error finding group in AWS")
 			return err
 		}
+
 		if gg != nil {
 			log.Debug("Found group")
 			correlatedGroups[gg.DisplayName] = gg
 			group = gg
 		} else {
 			log.Info("Creating group in AWS")
-			newGroup, err := s.aws.CreateGroup(aws.NewGroup(g.Email))
+			newGroup := aws.NewGroup(g.Email)
+			createGroupOutput, err := s.identityStoreClient.CreateGroup(&identitystore.CreateGroupInput{IdentityStoreId: &s.cfg.IdentityStoreID, DisplayName: &g.Email})
 			if err != nil {
-				log.WithField("group", g.Email).Warn("Error creating group in AWS")
 				return err
 			}
-			log.WithFields(Fields{
-				"group": newGroup.DisplayName,
-				"id":    newGroup.ID,
-			}).Info("Group created successfully in AWS")
+			newGroup.ID = *createGroupOutput.GroupId
 			correlatedGroups[newGroup.DisplayName] = newGroup
 			group = newGroup
 		}
+
 		groupMembers, err := s.google.GetGroupMembers(g)
 		if err != nil {
-			log.WithField("group", g.Email).Warn("Error getting group members from Google")
 			return err
 		}
-		log.WithFields(Fields{
-			"group": g.Email,
-			"count": len(groupMembers),
-		}).Info("Group members retrieved from Google")
+
 		memberList := make(map[string]*admin.Member)
+
 		log.Info("Start group user sync")
+
 		for _, m := range groupMembers {
 			if _, ok := s.users[m.Email]; ok {
 				memberList[m.Email] = m
 			}
 		}
+
 		for _, u := range s.users {
 			log.WithField("user", u.Username).Debug("Checking user is in group already")
-			b, err := s.aws.IsUserInGroup(u, group)
+			b, err := s.IsUserInGroup(u, group)
 			if err != nil {
-				log.WithFields(Fields{
-					"user":  u.Username,
-					"group": group.DisplayName,
-				}).Warn("Error checking user membership in AWS group")
 				return err
 			}
+
 			if _, ok := memberList[u.Username]; ok {
-				if !b {
-					log.WithFields(Fields{
-						"user":  u.Username,
-						"group": group.DisplayName,
-					}).Info("Adding user to group")
-					err := s.aws.AddUserToGroup(u, group)
+				if !*b {
+					log.WithField("user", u.Username).Info("Adding user to group")
+					_, err = s.identityStoreClient.CreateGroupMembership(
+						&identitystore.CreateGroupMembershipInput{
+							IdentityStoreId: &s.cfg.IdentityStoreID,
+							GroupId:         &group.ID,
+							MemberId:        &identitystore.MemberId{UserId: &u.ID},
+						},
+					)
 					if err != nil {
-						log.WithFields(Fields{
-							"user":  u.Username,
-							"group": group.DisplayName,
-						}).Warn("Error adding user to group in AWS")
 						return err
 					}
-					log.WithFields(Fields{
-						"user":  u.Username,
-						"group": group.DisplayName,
-					}).Info("User added to group successfully in AWS")
 				}
 			} else {
-				if b {
-					log.WithFields(Fields{
-						"user":  u.Username,
-						"group": group.DisplayName,
-					}).Warn("Removing user from group")
-					err := s.aws.RemoveUserFromGroup(u, group)
+				if *b {
+					log.WithField("user", u.Username).Warn("Removing user from group")
+					err := s.RemoveUserFromGroup(&u.ID, &group.ID)
 					if err != nil {
-						log.WithFields(Fields{
-							"user":  u.Username,
-							"group": group.DisplayName,
-						}).Warn("Error removing user from group in AWS")
 						return err
 					}
-					log.WithFields(Fields{
-						"user":  u.Username,
-						"group": group.DisplayName,
-					}).Info("User removed from group successfully in AWS")
 				}
 			}
 		}
 	}
+
 	return nil
 }
 
@@ -324,121 +270,128 @@ func (s *syncGSuite) SyncGroups(query string) error {
 // References:
 // * https://developers.google.com/admin-sdk/directory/v1/guides/search-groups
 // query possible values:
-// ” --> empty or not defined
-//
-//	name='contact'
-//	email:admin*
-//	memberKey=user@company.com
-//	name:contact* email:contact*
-//	name:Admin* email:aws-*
-//	email:aws-*
-//
+// '' --> empty or not defined
+//  name='contact'
+//  email:admin*
+//  memberKey=user@company.com
+//  name:contact* email:contact*
+//  name:Admin* email:aws-*
+//  email:aws-*
 // process workflow:
-//  1. delete users in aws, these were deleted in google
-//  2. update users in aws, these were updated in google
-//  3. add users in aws, these were added in google
-//  4. add groups in aws and add its members, these were added in google
-//  5. validate equals aws an google groups members
-//  6. delete groups in aws, these were deleted in google
-func (s *syncGSuite) SyncGroupsUsers(query string) error {
-	log.WithField("query", query).Info("get google groups")
-	googleGroups, err := s.google.GetGroups(query)
+//  1) delete users in aws, these were deleted in google
+//  2) update users in aws, these were updated in google
+//  3) add users in aws, these were added in google
+//  4) add groups in aws and add its members, these were added in google
+//  5) validate equals aws an google groups members
+//  6) delete groups in aws, these were deleted in google
+func (s *syncGSuite) SyncGroupsUsers(queryGroups string, queryUsers string) error {
+
+	log.WithField("queryGroup", queryGroups).Info("get google groups")
+	log.WithField("queryUsers", queryUsers).Info("get google users")
+
+	log.Debug("preparing list of google users, groups and their members")
+	googleGroups, googleUsers, googleGroupsUsers, err := s.getGoogleGroupsAndUsers(queryGroups, queryUsers)
 	if err != nil {
-		log.WithField("query", query).Warn("Error getting Google groups")
 		return err
 	}
-	log.WithField("count", len(googleGroups)).Info("Google groups retrieved")
-	filteredGoogleGroups := []*admin.Group{}
-	for _, g := range googleGroups {
-		if s.ignoreGroup(g.Email) {
-			log.WithField("group", g.Email).Debug("ignoring group")
-			continue
-		}
-		filteredGoogleGroups = append(filteredGoogleGroups, g)
-	}
-	googleGroups = filteredGoogleGroups
-	log.Debug("preparing list of google users and then google groups and their members")
-	googleUsers, googleGroupsUsers, err := s.getGoogleGroupsAndUsers(googleGroups)
-	if err != nil {
-		log.Warn("Error getting Google groups and users")
-		return err
-	}
-	log.WithFields(log.Fields{
-		"googleUsers":  len(googleUsers),
-		"googleGroups": len(googleGroupsUsers),
-	}).Info("Google users and groups retrieved")
+
 	log.Info("get existing aws groups")
-	awsGroups, err := s.aws.GetGroups()
+	awsGroups, err := s.GetGroups()
 	if err != nil {
 		log.Error("error getting aws groups")
 		return err
 	}
-	log.WithField("count", len(awsGroups)).Info("AWS groups retrieved")
+
 	log.Info("get existing aws users")
-	awsUsers, err := s.aws.GetUsers()
+	awsUsers, err := s.GetUsers()
 	if err != nil {
 		log.Error("error getting aws users")
 		return err
 	}
-	log.WithField("count", len(awsUsers)).Info("AWS users retrieved")
+
+	log.Info("get active status for aws users")
+	for _, awsUser := range awsUsers {
+		scimUser, err := s.aws.FindUserByEmail(awsUser.Username)
+
+		if err != nil {
+			log.Error("error getting active status for user " + awsUser.ID)
+			return err
+		}
+
+		awsUser.Active = scimUser.Active
+	}
+
+	log.Info("preparing map of user id's to user")
+	awsUsersMap := CreateUserIDtoUserObjMap(awsUsers)
+
 	log.Debug("preparing list of aws groups and their members")
-	awsGroupsUsers, err := s.getAWSGroupsAndUsers(awsGroups, awsUsers)
+	awsGroupsUsers, err := s.GetGroupMembershipsLists(awsGroups, awsUsersMap)
 	if err != nil {
-		log.Warn("Error getting AWS groups and users")
 		return err
 	}
-	log.WithField("count", len(awsGroupsUsers)).Info("AWS groups and users retrieved")
+
 	// create list of changes by operations
 	addAWSUsers, delAWSUsers, updateAWSUsers, _ := getUserOperations(awsUsers, googleUsers)
 	addAWSGroups, delAWSGroups, equalAWSGroups := getGroupOperations(awsGroups, googleGroups)
-	log.WithFields(log.Fields{
-		"addAWSUsers":    len(addAWSUsers),
-		"delAWSUsers":    len(delAWSUsers),
-		"updateAWSUsers": len(updateAWSUsers),
-		"addAWSGroups":   len(addAWSGroups),
-		"delAWSGroups":   len(delAWSGroups),
-		"equalAWSGroups": len(equalAWSGroups),
-	}).Info("Changes to be applied")
+
 	log.Info("syncing changes")
 	// delete aws users (deleted in google)
 	log.Debug("deleting aws users deleted in google")
+	if !checkUserDeletionThreshold(delAWSUsers) {
+		log.Error("Deletion threshold exceeded for users")
+		return errors.New("deletion threshold exceeded for users")
+	}
 	for _, awsUser := range delAWSUsers {
+
 		log := log.WithFields(log.Fields{"user": awsUser.Username})
+
 		log.Debug("finding user")
 		awsUserFull, err := s.aws.FindUserByEmail(awsUser.Username)
 		if err != nil {
-			log.Warn("Error finding user in AWS")
 			return err
 		}
+
 		log.Warn("deleting user")
-		if err := s.aws.DeleteUser(awsUserFull); err != nil {
+		_, err = s.identityStoreClient.DeleteUser(
+			&identitystore.DeleteUserInput{IdentityStoreId: &s.cfg.IdentityStoreID, UserId: &awsUserFull.ID},
+		)
+		if err != nil {
 			log.Error("error deleting user")
 			return err
 		}
-		log.Info("User deleted successfully in AWS")
 	}
+
 	// update aws users (updated in google)
 	log.Debug("updating aws users updated in google")
 	for _, awsUser := range updateAWSUsers {
+
 		log := log.WithFields(log.Fields{"user": awsUser.Username})
+
 		log.Debug("finding user")
 		awsUserFull, err := s.aws.FindUserByEmail(awsUser.Username)
 		if err != nil {
-			log.Warn("Error finding user in AWS")
 			return err
 		}
+
 		log.Warn("updating user")
-		_, err = s.aws.UpdateUser(awsUserFull)
+		_, err = s.aws.UpdateUser(aws.UpdateUser(
+			awsUserFull.ID,
+			awsUser.Name.GivenName,
+			awsUser.Name.FamilyName,
+			awsUser.Username,
+			awsUser.Active))
 		if err != nil {
 			log.Error("error updating user")
 			return err
 		}
-		log.Info("User updated successfully in AWS")
 	}
+
 	// add aws users (added in google)
 	log.Debug("creating aws users added in google")
 	for _, awsUser := range addAWSUsers {
+
 		log := log.WithFields(log.Fields{"user": awsUser.Username})
+
 		log.Info("creating user")
 		_, err := s.aws.CreateUser(awsUser)
 		if err != nil {
@@ -450,334 +403,300 @@ func (s *syncGSuite) SyncGroupsUsers(query string) error {
 			log.Error("error creating user")
 			return err
 		}
-		log.Info("User created successfully in AWS")
 	}
+
 	// add aws groups (added in google)
 	log.Debug("creating aws groups added in google")
 	for _, awsGroup := range addAWSGroups {
+
 		log := log.WithFields(log.Fields{"group": awsGroup.DisplayName})
+
 		log.Info("creating group")
-		_, err := s.aws.CreateGroup(awsGroup)
+		newAwsGroup, err := s.identityStoreClient.CreateGroup(
+			&identitystore.CreateGroupInput{IdentityStoreId: &s.cfg.IdentityStoreID, DisplayName: &awsGroup.DisplayName},
+		)
 		if err != nil {
 			log.Error("creating group")
 			return err
 		}
-		log.Info("Group created successfully in AWS")
+
 		// add members of the new group
 		for _, googleUser := range googleGroupsUsers[awsGroup.DisplayName] {
+
 			// equivalent aws user of google user on the fly
 			log.Debug("finding user")
 			awsUserFull, err := s.aws.FindUserByEmail(googleUser.PrimaryEmail)
 			if err != nil {
-				log.WithField("email", googleUser.PrimaryEmail).Warn("Error finding user in AWS")
 				return err
 			}
+
 			log.WithField("user", awsUserFull.Username).Info("adding user to group")
-			err = s.aws.AddUserToGroup(awsUserFull, awsGroup)
+			_, err = s.identityStoreClient.CreateGroupMembership(
+				&identitystore.CreateGroupMembershipInput{
+					IdentityStoreId: &s.cfg.IdentityStoreID,
+					GroupId:         newAwsGroup.GroupId,
+					MemberId:        &identitystore.MemberId{UserId: &awsUserFull.ID},
+				},
+			)
 			if err != nil {
-				log.WithFields(Fields{
-					"user":  awsUserFull.Username,
-					"group": awsGroup.DisplayName,
-				}).Warn("Error adding user to group in AWS")
 				return err
 			}
-			log.WithFields(Fields{
-				"user":  awsUserFull.Username,
-				"group": awsGroup.DisplayName,
-			}).Info("User added to group successfully in AWS")
 		}
 	}
+
 	// list of users to to be removed in aws groups
 	deleteUsersFromGroup, _ := getGroupUsersOperations(googleGroupsUsers, awsGroupsUsers)
+
 	// validate groups members are equal in aws and google
 	log.Debug("validating groups members, equals in aws and google")
 	for _, awsGroup := range equalAWSGroups {
+
 		// add members of the new group
 		log := log.WithFields(log.Fields{"group": awsGroup.DisplayName})
+
 		for _, googleUser := range googleGroupsUsers[awsGroup.DisplayName] {
+
 			log.WithField("user", googleUser.PrimaryEmail).Debug("finding user")
 			awsUserFull, err := s.aws.FindUserByEmail(googleUser.PrimaryEmail)
 			if err != nil {
-				log.WithField("email", googleUser.PrimaryEmail).Warn("Error finding user in AWS")
 				return err
 			}
+
 			log.WithField("user", awsUserFull.Username).Debug("checking user is in group already")
-			b, err := s.aws.IsUserInGroup(awsUserFull, awsGroup)
+			b, err := s.IsUserInGroup(awsUserFull, awsGroup)
 			if err != nil {
-				log.WithFields(Fields{
-					"user":  awsUserFull.Username,
-					"group": awsGroup.DisplayName,
-				}).Warn("Error checking user membership in AWS group")
 				return err
 			}
-			if !b {
+
+			if !*b {
 				log.WithField("user", awsUserFull.Username).Info("adding user to group")
-				err := s.aws.AddUserToGroup(awsUserFull, awsGroup)
+				_, err = s.identityStoreClient.CreateGroupMembership(
+					&identitystore.CreateGroupMembershipInput{
+						IdentityStoreId: &s.cfg.IdentityStoreID,
+						GroupId:         &awsGroup.ID,
+						MemberId:        &identitystore.MemberId{UserId: &awsUserFull.ID},
+					},
+				)
 				if err != nil {
-					log.WithFields(Fields{
-						"user":  awsUserFull.Username,
-						"group": awsGroup.DisplayName,
-					}).Warn("Error adding user to group in AWS")
 					return err
 				}
-				log.WithFields(Fields{
-					"user":  awsUserFull.Username,
-					"group": awsGroup.DisplayName,
-				}).Info("User added to group successfully in AWS")
 			}
 		}
+
 		for _, awsUser := range deleteUsersFromGroup[awsGroup.DisplayName] {
 			log.WithField("user", awsUser.Username).Warn("removing user from group")
-			err := s.aws.RemoveUserFromGroup(awsUser, awsGroup)
+			err := s.RemoveUserFromGroup(&awsUser.ID, &awsGroup.ID)
 			if err != nil {
-				log.WithFields(Fields{
-					"user":  awsUser.Username,
-					"group": awsGroup.DisplayName,
-				}).Warn("Error removing user from group in AWS")
 				return err
 			}
-			log.WithFields(Fields{
-				"user":  awsUser.Username,
-				"group": awsGroup.DisplayName,
-			}).Info("User removed from group successfully in AWS")
 		}
 	}
+
 	// delete aws groups (deleted in google)
 	log.Debug("delete aws groups deleted in google")
+	if !checkGroupDeletionThreshold(delAWSGroups) {
+		log.Error("Deletion threshold exceeded for groups")
+		return errors.New("deletion threshold exceeded for groups")
+	}
 	for _, awsGroup := range delAWSGroups {
+
 		log := log.WithFields(log.Fields{"group": awsGroup.DisplayName})
+
 		log.Debug("finding group")
 		awsGroupFull, err := s.aws.FindGroupByDisplayName(awsGroup.DisplayName)
 		if err != nil {
-			log.WithField("group", awsGroup.DisplayName).Warn("Error finding group in AWS")
 			return err
 		}
+
 		log.Warn("deleting group")
-		err = s.aws.DeleteGroup(awsGroupFull)
+		_, err = s.identityStoreClient.DeleteGroup(
+			&identitystore.DeleteGroupInput{IdentityStoreId: &s.cfg.IdentityStoreID, GroupId: &awsGroupFull.ID},
+		)
 		if err != nil {
 			log.Error("deleting group")
 			return err
 		}
-		log.Info("Group deleted successfully in AWS")
 	}
+
 	log.Info("sync completed")
+
 	return nil
 }
 
 // getGoogleGroupsAndUsers return a list of google users members of googleGroups
 // and a map of google groups and its users' list
-func (s *syncGSuite) getGoogleGroupsAndUsers(googleGroups []*admin.Group) ([]*admin.User, map[string][]*admin.User, error) {
-	log.WithField("count", len(googleGroups)).Info("Getting Google groups and users")
+func (s *syncGSuite) getGoogleGroupsAndUsers(queryGroups string, queryUsers string) ([]*admin.Group, []*admin.User, map[string][]*admin.User, error) {
 	gUsers := make([]*admin.User, 0)
 	gGroupsUsers := make(map[string][]*admin.User)
+        gUserDetailCache := make(map[string]*admin.User)
+        gGroupDetailCache := make(map[string]*admin.Group)
 	gUniqUsers := make(map[string]*admin.User)
-	for _, g := range googleGroups {
+
+        // For large directories this will reduce execution time and avoid throttling limits
+        log.Debug("Fetching ALL users from google, to use as cache")
+	googleUsers, err := s.google.GetUsers("*")
+        if err != nil {
+                return nil, nil, nil, err
+        }
+        for _, u := range googleUsers {
+                gUserDetailCache[u.PrimaryEmail] = u
+        }
+
+        log.Debug("Fetching ALL groups from google, to use as cache")
+	googleGroups, err := s.google.GetGroups("*")
+        if err != nil {
+                return nil, nil, nil, err
+        }
+        for _, g := range googleGroups {
+                gGroupDetailCache[g.Email] = g
+        }
+
+	// Fetch Users
+        log.Debug("get users from google, based on UserMatch,  regardless of group membership")
+        googleUsers, err = s.google.GetUsers(queryUsers)
+        if err != nil {
+                return nil, nil, nil, err
+        }
+
+        log.Debug("process users from google, filtering as required")
+	for _, u := range googleUsers {
+		log.WithField("email", u.PrimaryEmail).Debug("processing member")
+
+                // Remove any users that should be ignored
+		if s.ignoreUser(u.PrimaryEmail) {
+                	log.WithField("id", u.PrimaryEmail).Debug("ignoring user")
+			continue
+		}
+                _, ok := gUniqUsers[u.PrimaryEmail]
+                if !ok {
+                	log.WithField("id", u.PrimaryEmail).Debug("adding user")
+                	gUniqUsers[u.PrimaryEmail] = u
+                }
+
+        }
+
+	log.Debug("get groups from google")
+        gGroups, err := s.google.GetGroups(queryGroups)
+        if err != nil {
+                return nil, nil, nil, err
+        }
+        filteredGoogleGroups := []*admin.Group{}
+        for _, g := range gGroups {
+                if s.ignoreGroup(g.Email) {
+                        log.WithField("group", g.Email).Debug("ignoring group")
+                        continue
+                }
+                filteredGoogleGroups = append(filteredGoogleGroups, g)
+        }
+        gGroups = filteredGoogleGroups
+
+        log.Debug("for each group retrieve the group members")
+	for _, g := range gGroups {
+
 		log := log.WithFields(log.Fields{"group": g.Name})
+
 		if s.ignoreGroup(g.Email) {
 			log.Debug("ignoring group")
 			continue
 		}
+
 		log.Debug("get group members from google")
-		groupMembers, err := s.google.GetGroupMembers(g)
-		if err != nil {
-			log.WithField("group", g.Email).Warn("Error getting group members from Google")
-			return nil, nil, err
-		}
-		log.WithField("count", len(groupMembers)).Info("Group members retrieved from Google")
-		log.Debug("get users")
-		membersUsers := make([]*admin.User, 0)
-		for _, m := range groupMembers {
-			if s.ignoreUser(m.Email) {
-				log.WithField("id", m.Email).Debug("ignoring user")
-				continue
-			}
-			if m.Type == "GROUP" {
-				log.WithField("id", m.Email).Debug("ignoring group address")
-				continue
-			}
-			log.WithField("id", m.Email).Debug("get user")
-			q := fmt.Sprintf("email:%s", m.Email)
-			u, err := s.google.GetUsers(q) // TODO: implement GetUser(m.Email)
-			if err != nil {
-				log.WithField("email", m.Email).Warn("Error getting user from Google")
-				return nil, nil, err
-			}
-			if len(u) == 0 {
-				log.WithField("email", m.Email).Debug("Ignoring Unknown User")
-				continue
-			}
-			log.WithFields(Fields{
-				"email":      u[0].PrimaryEmail,
-				"givenName":  u[0].Name.GivenName,
-				"familyName": u[0].Name.FamilyName,
-			}).Info("User retrieved from Google")
-			membersUsers = append(membersUsers, u[0])
-			_, ok := gUniqUsers[m.Email]
+		membersUsers := s.getGoogleUsersInGroup(g, gUserDetailCache, gGroupDetailCache)
+
+		// If we've not seen the user email address before add it to the list of unique users
+                for _, m := range membersUsers {
+			_, ok := gUniqUsers[m.PrimaryEmail]
 			if !ok {
-				gUniqUsers[m.Email] = u[0]
+				gUniqUsers[m.PrimaryEmail] = gUserDetailCache[m.PrimaryEmail]
 			}
 		}
 		gGroupsUsers[g.Name] = membersUsers
-		log.WithFields(Fields{
-			"group": g.Name,
-			"count": len(membersUsers),
-		}).Info("Group members added to map")
 	}
+
 	for _, user := range gUniqUsers {
 		gUsers = append(gUsers, user)
 	}
-	log.WithFields(log.Fields{
-		"uniqueUsers": len(gUniqUsers),
-		"totalUsers":  len(gUsers),
-	}).Info("Google users retrieved")
-	return gUsers, gGroupsUsers, nil
-}
 
-// getAWSGroupsAndUsers return a list of google users members of googleGroups
-// and a map of google groups and its users' list
-func (s *syncGSuite) getAWSGroupsAndUsers(awsGroups []*aws.Group, awsUsers []*aws.User) (map[string][]*aws.User, error) {
-	log.WithFields(log.Fields{
-		"groups": len(awsGroups),
-		"users":  len(awsUsers),
-	}).Info("Getting AWS groups and users")
-	awsGroupsUsers := make(map[string][]*aws.User)
-	for _, awsGroup := range awsGroups {
-		users := make([]*aws.User, 0)
-		log := log.WithFields(log.Fields{"group": awsGroup.DisplayName})
-		log.Debug("get group members from aws")
-		// NOTE: AWS has not implemented yet some method to get the groups members https://docs.aws.amazon.com/singlesignon/latest/developerguide/listgroups.html
-		// so, we need to check each user in each group which are too many unnecessary API calls
-		for _, user := range awsUsers {
-			log.Debug("checking if user is member of")
-			found, err := s.aws.IsUserInGroup(user, awsGroup)
-			if err != nil {
-				log.WithFields(Fields{
-					"user":  user.Username,
-					"group": awsGroup.DisplayName,
-				}).Warn("Error checking user membership in AWS group")
-				return nil, err
-			}
-			if found {
-				users = append(users, user)
-				log.WithField("user", user.Username).Debug("User is a member of the group")
-			}
-		}
-		awsGroupsUsers[awsGroup.DisplayName] = users
-		log.WithField("count", len(users)).Info("Group members added to map")
-	}
-	log.WithField("count", len(awsGroupsUsers)).Info("AWS groups and users retrieved")
-	return awsGroupsUsers, nil
+	return gGroups, gUsers, gGroupsUsers, nil
 }
 
 // getGroupOperations returns the groups of AWS that must be added, deleted and are equals
 func getGroupOperations(awsGroups []*aws.Group, googleGroups []*admin.Group) (add []*aws.Group, delete []*aws.Group, equals []*aws.Group) {
-	log.WithFields(log.Fields{
-		"awsGroups":    len(awsGroups),
-		"googleGroups": len(googleGroups),
-	}).Info("Getting group operations")
+
 	awsMap := make(map[string]*aws.Group)
 	googleMap := make(map[string]struct{})
+
 	for _, awsGroup := range awsGroups {
 		awsMap[awsGroup.DisplayName] = awsGroup
 	}
+
 	for _, gGroup := range googleGroups {
 		googleMap[gGroup.Name] = struct{}{}
 	}
+
 	// AWS Groups found and not found in google
 	for _, gGroup := range googleGroups {
 		if _, found := awsMap[gGroup.Name]; found {
-			log.WithField("group", gGroup.Name).Debug("Group found in AWS and Google")
 			equals = append(equals, awsMap[gGroup.Name])
 		} else {
-			log.WithField("group", gGroup.Name).Info("Group not found in AWS, will be added")
 			add = append(add, aws.NewGroup(gGroup.Name))
 		}
 	}
+
 	// Google Groups founds and not in aws
 	for _, awsGroup := range awsGroups {
 		if _, found := googleMap[awsGroup.DisplayName]; !found {
-			log.WithField("group", awsGroup.DisplayName).Info("Group not found in Google, will be deleted from AWS")
 			delete = append(delete, aws.NewGroup(awsGroup.DisplayName))
 		}
 	}
-	log.WithFields(log.Fields{
-		"add":    len(add),
-		"delete": len(delete),
-		"equals": len(equals),
-	}).Info("Group operations determined")
+
 	return add, delete, equals
 }
 
 // getUserOperations returns the users of AWS that must be added, deleted, updated and are equals
 func getUserOperations(awsUsers []*aws.User, googleUsers []*admin.User) (add []*aws.User, delete []*aws.User, update []*aws.User, equals []*aws.User) {
-	log.WithFields(log.Fields{
-		"awsUsers":    len(awsUsers),
-		"googleUsers": len(googleUsers),
-	}).Info("Getting user operations")
+
 	awsMap := make(map[string]*aws.User)
 	googleMap := make(map[string]struct{})
+
 	for _, awsUser := range awsUsers {
 		awsMap[awsUser.Username] = awsUser
 	}
+
 	for _, gUser := range googleUsers {
 		googleMap[gUser.PrimaryEmail] = struct{}{}
 	}
+
 	// AWS Users found and not found in google
 	for _, gUser := range googleUsers {
 		if awsUser, found := awsMap[gUser.PrimaryEmail]; found {
-			log.WithField("user", gUser.PrimaryEmail).Debug("User found in AWS and Google")
 			if awsUser.Active == gUser.Suspended ||
 				awsUser.Name.GivenName != gUser.Name.GivenName ||
 				awsUser.Name.FamilyName != gUser.Name.FamilyName {
-				log.WithFields(log.Fields{
-					"user":       gUser.PrimaryEmail,
-					"givenName":  gUser.Name.GivenName,
-					"familyName": gUser.Name.FamilyName,
-					"suspended":  gUser.Suspended,
-				}).Info("User attributes mismatch, will be updated in AWS")
 				update = append(update, aws.NewUser(gUser.Name.GivenName, gUser.Name.FamilyName, gUser.PrimaryEmail, !gUser.Suspended))
 			} else {
-				log.WithField("user", gUser.PrimaryEmail).Debug("User attributes match in AWS and Google")
 				equals = append(equals, awsUser)
 			}
 		} else {
-			log.WithFields(log.Fields{
-				"user":       gUser.PrimaryEmail,
-				"givenName":  gUser.Name.GivenName,
-				"familyName": gUser.Name.FamilyName,
-				"suspended":  gUser.Suspended,
-			}).Info("User not found in AWS, will be added")
 			add = append(add, aws.NewUser(gUser.Name.GivenName, gUser.Name.FamilyName, gUser.PrimaryEmail, !gUser.Suspended))
 		}
 	}
+
 	// Google Users founds and not in aws
 	for _, awsUser := range awsUsers {
 		if _, found := googleMap[awsUser.Username]; !found {
-			log.WithFields(log.Fields{
-				"user":       awsUser.Username,
-				"givenName":  awsUser.Name.GivenName,
-				"familyName": awsUser.Name.FamilyName,
-				"active":     awsUser.Active,
-			}).Info("User not found in Google, will be deleted from AWS")
 			delete = append(delete, aws.NewUser(awsUser.Name.GivenName, awsUser.Name.FamilyName, awsUser.Username, awsUser.Active))
 		}
 	}
-	log.WithFields(log.Fields{
-		"add":    len(add),
-		"delete": len(delete),
-		"update": len(update),
-		"equals": len(equals),
-	}).Info("User operations determined")
+
 	return add, delete, update, equals
 }
 
 // groupUsersOperations returns the groups and its users of AWS that must be delete from these groups and what are equals
 func getGroupUsersOperations(gGroupsUsers map[string][]*admin.User, awsGroupsUsers map[string][]*aws.User) (delete map[string][]*aws.User, equals map[string][]*aws.User) {
-	log.WithFields(log.Fields{
-		"googleGroups": len(gGroupsUsers),
-		"awsGroups":    len(awsGroupsUsers),
-	}).Info("Getting group users operations")
+
 	mbG := make(map[string]map[string]struct{})
+
 	// get user in google groups that are in aws groups and
 	// users in aws groups that aren't in google groups
 	for gGroupName, gGroupUsers := range gGroupsUsers {
@@ -786,96 +705,116 @@ func getGroupUsersOperations(gGroupsUsers map[string][]*admin.User, awsGroupsUse
 			mbG[gGroupName][gUser.PrimaryEmail] = struct{}{}
 		}
 	}
+
 	delete = make(map[string][]*aws.User)
 	equals = make(map[string][]*aws.User)
 	for awsGroupName, awsGroupUsers := range awsGroupsUsers {
 		for _, awsUser := range awsGroupUsers {
 			// users that exist in aws groups but doesn't in google groups
 			if _, found := mbG[awsGroupName][awsUser.Username]; found {
-				log.WithFields(log.Fields{
-					"user":  awsUser.Username,
-					"group": awsGroupName,
-				}).Debug("User found in AWS group and Google group")
 				equals[awsGroupName] = append(equals[awsGroupName], awsUser)
 			} else {
-				log.WithFields(log.Fields{
-					"user":  awsUser.Username,
-					"group": awsGroupName,
-				}).Info("User found in AWS group but not in Google group, will be removed from AWS group")
 				delete[awsGroupName] = append(delete[awsGroupName], awsUser)
 			}
 		}
 	}
-	log.WithFields(log.Fields{
-		"delete": len(delete),
-		"equals": len(equals),
-	}).Info("Group users operations determined")
+
 	return
 }
 
 // DoSync will create a logger and run the sync with the paths
 // given to do the sync.
 func DoSync(ctx context.Context, cfg *config.Config) error {
-	log.Info("Starting synchronization process")
 	log.Info("Syncing AWS users and groups from Google Workspace SAML Application")
+
 	creds := []byte(cfg.GoogleCredentials)
+
 	if !cfg.IsLambda {
 		b, err := ioutil.ReadFile(cfg.GoogleCredentials)
 		if err != nil {
-			log.WithError(err).Error("Error reading Google credentials file")
 			return err
 		}
 		creds = b
 	}
+
 	// create a http client with retry and backoff capabilities
 	retryClient := retryablehttp.NewClient()
+
 	// https://github.com/hashicorp/go-retryablehttp/issues/6
 	if cfg.Debug {
 		retryClient.Logger = log.StandardLogger()
 	} else {
 		retryClient.Logger = nil
 	}
+
 	httpClient := retryClient.StandardClient()
-	googleClient, err := google.NewClient(ctx, cfg.GoogleAdmin, creds, cfg.GoogleCustomerId)
+
+	googleClient, err := google.NewClient(ctx, cfg.GoogleAdmin, creds)
 	if err != nil {
-		log.WithError(err).Error("Error creating Google client")
+	        log.WithField("error", err).Warn("Problem establising a connection to Google directory")
 		return err
 	}
-	log.Info("Google client created successfully")
-	awsClient, err := aws.NewClient(
+
+	awsScimClient, err := aws.NewClient(
 		httpClient,
 		&aws.Config{
 			Endpoint: cfg.SCIMEndpoint,
 			Token:    cfg.SCIMAccessToken,
 		})
 	if err != nil {
-		log.WithError(err).Error("Error creating AWS client")
+	        log.WithField("error", err).Warn("Problem establising a SCIM connection to AWS IAM Identity Center")
 		return err
 	}
-	log.Info("AWS client created successfully")
-	c := New(cfg, awsClient, googleClient)
-	log.WithField("sync_method", cfg.SyncMethod).Info("Starting synchronization")
+
+	// Initialize AWS session
+	sess, err := aws_sdk_sess.NewSession(&aws_sdk.Config{
+		// AWS Region to send requests to, provided by config
+		Region: &cfg.Region,
+	})
+
+	if err != nil {
+	        log.WithField("error", err).Warn("Problem establising a session for Identity Store")
+		return err
+	}
+
+	// Initialize AWS Identity Store Public API Client with session
+	identityStoreClient := identitystore.New(sess)
+
+	response, err := identityStoreClient.ListGroups(
+                &identitystore.ListGroupsInput{IdentityStoreId: &cfg.IdentityStoreID})
+
+	if err != nil {
+	        log.WithField("error", err).Warn("Problem performing test query against Identity Store")
+		return err
+	} else {
+	        log.WithField("Groups", response).Info("Test call for groups successful")
+                
+        }
+
+	// Initialize sync client with
+	// 1. SCIM API client
+	// 2. Google Directory API client
+	// 3. Identity Store Public API client
+	c := New(cfg, awsScimClient, googleClient, identityStoreClient)
+
+	log.WithField("sync_method", cfg.SyncMethod).Info("syncing")
 	if cfg.SyncMethod == config.DefaultSyncMethod {
-		log.Info("Using default synchronization method")
-		err = c.SyncGroupsUsers(cfg.GroupMatch)
+		err = c.SyncGroupsUsers(cfg.GroupMatch, cfg.UserMatch)
 		if err != nil {
-			log.WithError(err).Error("Error synchronizing groups and users")
 			return err
 		}
 	} else {
-		log.Info("Using alternative synchronization method")
 		err = c.SyncUsers(cfg.UserMatch)
 		if err != nil {
-			log.WithError(err).Error("Error synchronizing users")
 			return err
 		}
+
 		err = c.SyncGroups(cfg.GroupMatch)
 		if err != nil {
-			log.WithError(err).Error("Error synchronizing groups")
 			return err
 		}
 	}
-	log.Info("Synchronization completed successfully")
+
 	return nil
 }
 
@@ -907,4 +846,277 @@ func (s *syncGSuite) includeGroup(name string) bool {
 	}
 
 	return false
+}
+
+var awsGroups []*aws.Group
+
+func (s *syncGSuite) GetGroups() ([]*aws.Group, error) {
+	awsGroups = make([]*aws.Group, 0)
+
+	err := s.identityStoreClient.ListGroupsPages(
+		&identitystore.ListGroupsInput{IdentityStoreId: &s.cfg.IdentityStoreID},
+		ListGroupsPagesCallbackFn,
+	)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return awsGroups, nil
+}
+
+func ListGroupsPagesCallbackFn(page *identitystore.ListGroupsOutput, lastPage bool) bool {
+	// Loop through each Group returned
+	for _, group := range page.Groups {
+		// Convert to native Group object
+		awsGroups = append(awsGroups, &aws.Group{
+			ID:          *group.GroupId,
+			Schemas:     []string{"urn:ietf:params:scim:schemas:core:2.0:Group"},
+			DisplayName: *group.DisplayName,
+			Members:     []string{},
+		})
+	}
+
+	return !lastPage
+}
+
+var awsUsers []*aws.User
+
+func (s *syncGSuite) GetUsers() ([]*aws.User, error) {
+	awsUsers = make([]*aws.User, 0)
+
+	err := s.identityStoreClient.ListUsersPages(
+		&identitystore.ListUsersInput{IdentityStoreId: &s.cfg.IdentityStoreID},
+		ListUsersPagesCallbackFn,
+	)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return awsUsers, nil
+}
+
+func ListUsersPagesCallbackFn(page *identitystore.ListUsersOutput, lastPage bool) bool {
+	// Loop through each User in ListUsersOutput and convert to native User object
+	for _, user := range page.Users {
+		awsUsers = append(awsUsers, ConvertSdkUserObjToNative(user))
+	}
+	return !lastPage
+}
+
+func ConvertSdkUserObjToNative(user *identitystore.User) *aws.User {
+	// Convert emails into native Email object
+	userEmails := make([]aws.UserEmail, 0)
+
+	for _, email := range user.Emails {
+		if email.Value == nil || email.Type == nil || email.Primary == nil {
+              		// This must be a user created by AWS Control Tower
+                        // Need feature development to make how these users are treated
+			// configurable.
+			continue
+		}
+		userEmails = append(userEmails, aws.UserEmail{
+			Value:   *email.Value,
+			Type:    *email.Type,
+			Primary: *email.Primary,
+		})
+	}
+
+	// Convert addresses into native Address object
+	userAddresses := make([]aws.UserAddress, 0)
+
+	for _, address := range user.Addresses {
+		userAddresses = append(userAddresses, aws.UserAddress{
+			Type: *address.Type,
+		})
+	}
+
+	return &aws.User{
+		ID:       *user.UserId,
+		Schemas:  []string{"urn:ietf:params:scim:schemas:core:2.0:User"},
+		Username: *user.UserName,
+		Name: struct {
+			FamilyName string `json:"familyName"`
+			GivenName  string `json:"givenName"`
+		}{
+			FamilyName: *user.Name.FamilyName,
+			GivenName:  *user.Name.GivenName,
+		},
+		DisplayName: *user.DisplayName,
+		Emails:      userEmails,
+		Addresses:   userAddresses,
+	}
+}
+
+func CreateUserIDtoUserObjMap(awsUsers []*aws.User) map[string]*aws.User {
+	awsUsersMap := make(map[string]*aws.User)
+
+	for _, awsUser := range awsUsers {
+		awsUsersMap[awsUser.ID] = awsUser
+	}
+
+	return awsUsersMap
+}
+
+var ListGroupMembershipPagesCallbackFn func(page *identitystore.ListGroupMembershipsOutput, lastPage bool) bool
+
+func (s *syncGSuite) GetGroupMembershipsLists(awsGroups []*aws.Group, awsUsersMap map[string]*aws.User) (map[string][]*aws.User, error) {
+	awsGroupsUsers := make(map[string][]*aws.User)
+	curGroup := &aws.Group{}
+
+	ListGroupMembershipPagesCallbackFn = func(page *identitystore.ListGroupMembershipsOutput, lastPage bool) bool {
+		for _, member := range page.GroupMemberships { // For every member in the group
+			userId := member.MemberId.UserId
+			user := awsUsersMap[*userId]
+
+			// Append new user onto existing list of users
+			awsGroupsUsers[curGroup.DisplayName] = append(awsGroupsUsers[curGroup.DisplayName], user)
+		}
+
+		return !lastPage
+	}
+
+	// For every group, get the members and assign in awsGroupsUsers map
+	for _, group := range awsGroups {
+		curGroup = group
+		awsGroupsUsers[curGroup.DisplayName] = make([]*aws.User, 0)
+
+		// Get User ID of every member in group
+		err := s.identityStoreClient.ListGroupMembershipsPages(
+			&identitystore.ListGroupMembershipsInput{
+				IdentityStoreId: &s.cfg.IdentityStoreID,
+				GroupId:         &group.ID,
+			}, ListGroupMembershipPagesCallbackFn)
+
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return awsGroupsUsers, nil
+}
+
+func (s *syncGSuite) IsUserInGroup(user *aws.User, group *aws.Group) (*bool, error) {
+	isUserInGroupOutput, err := s.identityStoreClient.IsMemberInGroups(
+		&identitystore.IsMemberInGroupsInput{
+			IdentityStoreId: &s.cfg.IdentityStoreID,
+			GroupIds:        []*string{&group.ID},
+			MemberId:        &identitystore.MemberId{UserId: &user.ID},
+		},
+	)
+
+	if err != nil {
+		return nil, err
+	}
+
+	isUserInGroup := isUserInGroupOutput.Results[0].MembershipExists
+
+	return isUserInGroup, nil
+}
+
+func (s *syncGSuite) RemoveUserFromGroup(userId *string, groupId *string) error {
+	memberIdOutput, err := s.identityStoreClient.GetGroupMembershipId(
+		&identitystore.GetGroupMembershipIdInput{
+			IdentityStoreId: &s.cfg.IdentityStoreID,
+			GroupId:         groupId,
+			MemberId:        &identitystore.MemberId{UserId: userId},
+		},
+	)
+
+	if err != nil {
+		return err
+	}
+
+	memberId := memberIdOutput.MembershipId
+
+	_, err = s.identityStoreClient.DeleteGroupMembership(
+		&identitystore.DeleteGroupMembershipInput{
+			IdentityStoreId: &s.cfg.IdentityStoreID,
+			MembershipId:    memberId,
+		},
+	)
+
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (s *syncGSuite) getGoogleUsersInGroup(group *admin.Group, userCache map[string]*admin.User, groupCache map[string]*admin.Group) []*admin.User {
+	log.WithField("Email:", group.Email).Debug("getGoogleGroupMembers()")
+
+	 // retrieve the members of the group
+	groupMembers, err := s.google.GetGroupMembers(group)
+	if err != nil {
+		return nil
+	}
+        membersUsers := make([]*admin.User, 0)
+
+	// process the members of the group
+        for _, m := range groupMembers {
+        	log.WithField("email", m.Email).Debug("processing member")
+                // Ignore Owners aren't relevant in Identity Store
+		// so are treated as group members.
+                if m.Role == "OWNER" {
+                	log.WithField("id", m.Email).Debug("owner role")
+                }
+
+                // Ignore any external members, since they don't have users
+                // that can be synced
+                if m.Type == "USER" && m.Status != "ACTIVE" {
+                        log.WithField("id", m.Email).Warn("ignoring external user")
+                        continue
+                }
+
+                // handle nested groups, by adding their membership to the end
+                // of googleMembers
+                if m.Type == "GROUP" {
+		    	log.WithField("Email:", m.Email).Debug("calling getGoogleGroupMembers() for nested group")
+			_, found := groupCache[m.Email]
+			if found {
+                        	membersUsers = append (membersUsers, s.getGoogleUsersInGroup(groupCache[m.Email], userCache, groupCache)...)
+			} else {
+                        	log.WithField("id", m.Email).Warn("missing nested group")
+			}
+                        continue
+                }
+                // Remove any users that should be ignored
+                if s.ignoreUser(m.Email) {
+                        log.WithField("id", m.Email).Debug("ignoring user")
+                        continue
+                }
+
+                // Find the group member in the cache of UserDetails
+                _, found := userCache[m.Email]
+                if found {
+                        membersUsers = append(membersUsers, userCache[m.Email])
+                } else {
+                        log.WithField("id", m.Email).Warn("missing user")
+                        continue
+                }
+        }
+
+        return membersUsers
+}
+
+// checkUserDeletionThreshold checks if the number of users to be deleted exceeds the threshold.
+func checkUserDeletionThreshold(users []*aws.User) bool {
+    const deletionThreshold = 4 // Define the maximum number of users that can be deleted at once.
+    if len(users) > deletionThreshold {
+        log.Warnf("Attempt to delete %d users, which exceeds the threshold of %d", len(users), deletionThreshold)
+        return false
+    }
+    return true
+}
+
+// checkGroupDeletionThreshold checks if the number of groups to be deleted exceeds the threshold.
+func checkGroupDeletionThreshold(groups []*aws.Group) bool {
+    const deletionThreshold = 4 // Define the maximum number of groups that can be deleted at once.
+    if len(groups) > deletionThreshold {
+        log.Warnf("Attempt to delete %d groups, which exceeds the threshold of %d", len(groups), deletionThreshold)
+        return false
+    }
+    return true
 }

--- a/internal/sync.go
+++ b/internal/sync.go
@@ -917,21 +917,19 @@ func (s *syncGSuite) includeGroup(name string) bool {
 	return false
 }
 
-// checkUserDeletionThreshold checks if the number of users to be deleted exceeds the threshold.
 func checkUserDeletionThreshold(users []*aws.User) bool {
-    const deletionThreshold = 4 // Define the maximum number of users that can be deleted at once.
+    const deletionThreshold = 4
     if len(users) > deletionThreshold {
-        log.Warnf("Attempt to delete %d users, which exceeds the threshold of %d", len(users), deletionThreshold)
+        log.Warnf("Attempting to delete %d users, which exceeds the threshold of %d", len(users), deletionThreshold)
         return false
     }
     return true
 }
 
-// checkGroupDeletionThreshold checks if the number of groups to be deleted exceeds the threshold.
 func checkGroupDeletionThreshold(groups []*aws.Group) bool {
-    const deletionThreshold = 4 // Define the maximum number of groups that can be deleted at once.
+    const deletionThreshold = 4
     if len(groups) > deletionThreshold {
-        log.Warnf("Attempt to delete %d groups, which exceeds the threshold of %d", len(groups), deletionThreshold)
+        log.Warnf("Attempting to delete %d groups, which exceeds the threshold of %d", len(groups), deletionThreshold)
         return false
     }
     return true

--- a/internal/sync.go
+++ b/internal/sync.go
@@ -918,7 +918,7 @@ func (s *syncGSuite) includeGroup(name string) bool {
 }
 
 func checkUserDeletionThreshold(users []*aws.User) bool {
-    const deletionThreshold = 4
+    const deletionThreshold = 2
     if len(users) > deletionThreshold {
         log.Warnf("Attempting to delete %d users, which exceeds the threshold of %d", len(users), deletionThreshold)
         return false
@@ -927,7 +927,7 @@ func checkUserDeletionThreshold(users []*aws.User) bool {
 }
 
 func checkGroupDeletionThreshold(groups []*aws.Group) bool {
-    const deletionThreshold = 4
+    const deletionThreshold = 2
     if len(groups) > deletionThreshold {
         log.Warnf("Attempting to delete %d groups, which exceeds the threshold of %d", len(groups), deletionThreshold)
         return false

--- a/internal/sync.go
+++ b/internal/sync.go
@@ -18,6 +18,7 @@ package internal
 import (
 	"context"
 	"errors"
+	"fmt"
 	"io/ioutil"
 
 	"github.com/awslabs/ssosync/internal/aws"
@@ -25,39 +26,37 @@ import (
 	"github.com/awslabs/ssosync/internal/google"
 	"github.com/hashicorp/go-retryablehttp"
 
-	aws_sdk "github.com/aws/aws-sdk-go/aws"
-	aws_sdk_sess "github.com/aws/aws-sdk-go/aws/session"
-	"github.com/aws/aws-sdk-go/service/identitystore"
-	"github.com/aws/aws-sdk-go/service/identitystore/identitystoreiface"
 	log "github.com/sirupsen/logrus"
 	admin "google.golang.org/api/admin/directory/v1"
 )
+
+// Aiasing log.Fields to Fields as the `log` package get shadowed by locally
+// assignment to the `log` variable
+type Fields = log.Fields
 
 // SyncGSuite is the interface for synchronizing users/groups
 type SyncGSuite interface {
 	SyncUsers(string) error
 	SyncGroups(string) error
-	SyncGroupsUsers(string, string) error
+	SyncGroupsUsers(string) error
 }
 
 // SyncGSuite is an object type that will synchronize real users and groups
 type syncGSuite struct {
-	aws                 aws.Client
-	google              google.Client
-	cfg                 *config.Config
-	identityStoreClient identitystoreiface.IdentityStoreAPI
+	aws    aws.Client
+	google google.Client
+	cfg    *config.Config
 
 	users map[string]*aws.User
 }
 
 // New will create a new SyncGSuite object
-func New(cfg *config.Config, a aws.Client, g google.Client, ids identitystoreiface.IdentityStoreAPI) SyncGSuite {
+func New(cfg *config.Config, a aws.Client, g google.Client) SyncGSuite {
 	return &syncGSuite{
-		aws:                 a,
-		google:              g,
-		cfg:                 cfg,
-		identityStoreClient: ids,
-		users:               make(map[string]*aws.User),
+		aws:    a,
+		google: g,
+		cfg:    cfg,
+		users:  make(map[string]*aws.User),
 	}
 }
 
@@ -65,13 +64,14 @@ func New(cfg *config.Config, a aws.Client, g google.Client, ids identitystoreifa
 // References:
 // * https://developers.google.com/admin-sdk/directory/v1/guides/search-users
 // query possible values:
-// '' --> empty or not defined
-//  name:'Jane'
-//  email:admin*
-//  isAdmin=true
-//  manager='janesmith@example.com'
-//  orgName=Engineering orgTitle:Manager
-//  EmploymentData.projects:'GeneGnomes'
+// ” --> empty or not defined
+//
+//	name:'Jane'
+//	email:admin*
+//	isAdmin=true
+//	manager='janesmith@example.com'
+//	orgName=Engineering orgTitle:Manager
+//	EmploymentData.projects:'GeneGnomes'
 func (s *syncGSuite) SyncUsers(query string) error {
 	log.Debug("get deleted users")
 	deletedUsers, err := s.google.GetDeletedUsers()
@@ -79,12 +79,10 @@ func (s *syncGSuite) SyncUsers(query string) error {
 		log.Warn("Error Getting Deleted Users")
 		return err
 	}
-
 	for _, u := range deletedUsers {
 		log.WithFields(log.Fields{
 			"email": u.PrimaryEmail,
 		}).Info("deleting google user")
-
 		uu, err := s.aws.FindUserByEmail(u.PrimaryEmail)
 		if err != aws.ErrUserNotFound && err != nil {
 			log.WithFields(log.Fields{
@@ -92,44 +90,57 @@ func (s *syncGSuite) SyncUsers(query string) error {
 			}).Warn("Error deleting google user")
 			return err
 		}
-
 		if err == aws.ErrUserNotFound {
 			log.WithFields(log.Fields{
 				"email": u.PrimaryEmail,
 			}).Debug("User already deleted")
 			continue
 		}
-		_, err = s.identityStoreClient.DeleteUser(&identitystore.DeleteUserInput{IdentityStoreId: &s.cfg.IdentityStoreID, UserId: &uu.ID})
-		if err != nil {
+		log.WithFields(log.Fields{
+			"email":    u.PrimaryEmail,
+			"username": uu.Username,
+			"id":       uu.ID,
+		}).Info("Deleting user in AWS")
+		if err := s.aws.DeleteUser(uu); err != nil {
 			log.WithFields(log.Fields{
-				"email": u.PrimaryEmail,
+				"email":    u.PrimaryEmail,
+				"username": uu.Username,
+				"id":       uu.ID,
 			}).Warn("Error deleting user")
 			return err
 		}
+		log.WithFields(log.Fields{
+			"email":    u.PrimaryEmail,
+			"username": uu.Username,
+			"id":       uu.ID,
+		}).Info("User deleted successfully in AWS")
 	}
-
 	log.Debug("get active google users")
 	googleUsers, err := s.google.GetUsers(query)
 	if err != nil {
+		log.WithField("query", query).Warn("Error getting active Google users")
 		return err
 	}
-
+	log.WithField("count", len(googleUsers)).Info("Active Google users retrieved")
 	for _, u := range googleUsers {
 		if s.ignoreUser(u.PrimaryEmail) {
+			log.WithField("email", u.PrimaryEmail).Debug("Ignoring user based on configuration")
 			continue
 		}
-
 		ll := log.WithFields(log.Fields{
 			"email": u.PrimaryEmail,
 		})
-
 		ll.Debug("finding user")
 		uu, _ := s.aws.FindUserByEmail(u.PrimaryEmail)
 		if uu != nil {
 			s.users[uu.Username] = uu
 			// Update the user when suspended state is changed
 			if uu.Active == u.Suspended {
-				log.Debug("Mismatch active/suspended, updating user")
+				log.WithFields(log.Fields{
+					"email":    u.PrimaryEmail,
+					"username": uu.Username,
+					"id":       uu.ID,
+				}).Info("Mismatch active/suspended, updating user")
 				// create new user object and update the user
 				_, err := s.aws.UpdateUser(aws.UpdateUser(
 					uu.ID,
@@ -138,25 +149,49 @@ func (s *syncGSuite) SyncUsers(query string) error {
 					u.PrimaryEmail,
 					!u.Suspended))
 				if err != nil {
+					log.WithFields(log.Fields{
+						"email":    u.PrimaryEmail,
+						"username": uu.Username,
+						"id":       uu.ID,
+					}).Warn("Error updating user")
 					return err
 				}
+				log.WithFields(log.Fields{
+					"email":    u.PrimaryEmail,
+					"username": uu.Username,
+					"id":       uu.ID,
+				}).Info("User updated successfully")
 			}
 			continue
 		}
-
 		ll.Info("creating user")
+		log.WithFields(log.Fields{
+			"email":      u.PrimaryEmail,
+			"givenName":  u.Name.GivenName,
+			"familyName": u.Name.FamilyName,
+			"suspended":  u.Suspended,
+		}).Info("Creating user in AWS")
 		uu, err := s.aws.CreateUser(aws.NewUser(
 			u.Name.GivenName,
 			u.Name.FamilyName,
 			u.PrimaryEmail,
 			!u.Suspended))
 		if err != nil {
+			log.WithFields(log.Fields{
+				"email":      u.PrimaryEmail,
+				"givenName":  u.Name.GivenName,
+				"familyName": u.Name.FamilyName,
+				"suspended":  u.Suspended,
+			}).Warn("Error creating user")
 			return err
 		}
-
+		log.WithFields(log.Fields{
+			"email":    uu.Username,
+			"username": uu.Username,
+			"id":       uu.ID,
+		}).Info("User created successfully in AWS")
 		s.users[uu.Username] = uu
 	}
-
 	return nil
 }
 
@@ -164,104 +199,123 @@ func (s *syncGSuite) SyncUsers(query string) error {
 // References:
 // * https://developers.google.com/admin-sdk/directory/v1/guides/search-groups
 // query possible values:
-// '' --> empty or not defined
-//  name='contact'
-//  email:admin*
-//  memberKey=user@company.com
-//  name:contact* email:contact*
-//  name:Admin* email:aws-*
-//  email:aws-*
+// ” --> empty or not defined
+//
+//	name='contact'
+//	email:admin*
+//	memberKey=user@company.com
+//	name:contact* email:contact*
+//	name:Admin* email:aws-*
+//	email:aws-*
 func (s *syncGSuite) SyncGroups(query string) error {
-
 	log.WithField("query", query).Debug("get google groups")
 	googleGroups, err := s.google.GetGroups(query)
 	if err != nil {
+		log.WithField("query", query).Warn("Error getting Google groups")
 		return err
 	}
-
+	log.WithField("count", len(googleGroups)).Info("Google groups retrieved")
 	correlatedGroups := make(map[string]*aws.Group)
-
 	for _, g := range googleGroups {
 		if s.ignoreGroup(g.Email) || !s.includeGroup(g.Email) {
+			log.WithField("group", g.Email).Debug("Ignoring group based on configuration")
 			continue
 		}
-
 		log := log.WithFields(log.Fields{
 			"group": g.Email,
 		})
-
 		log.Debug("Check group")
 		var group *aws.Group
-
 		gg, err := s.aws.FindGroupByDisplayName(g.Email)
 		if err != nil && err != aws.ErrGroupNotFound {
+			log.WithField("group", g.Email).Warn("Error finding group in AWS")
 			return err
 		}
-
 		if gg != nil {
 			log.Debug("Found group")
 			correlatedGroups[gg.DisplayName] = gg
 			group = gg
 		} else {
 			log.Info("Creating group in AWS")
-			newGroup := aws.NewGroup(g.Email)
-			createGroupOutput, err := s.identityStoreClient.CreateGroup(&identitystore.CreateGroupInput{IdentityStoreId: &s.cfg.IdentityStoreID, DisplayName: &g.Email})
+			newGroup, err := s.aws.CreateGroup(aws.NewGroup(g.Email))
 			if err != nil {
+				log.WithField("group", g.Email).Warn("Error creating group in AWS")
 				return err
 			}
-			newGroup.ID = *createGroupOutput.GroupId
+			log.WithFields(Fields{
+				"group": newGroup.DisplayName,
+				"id":    newGroup.ID,
+			}).Info("Group created successfully in AWS")
 			correlatedGroups[newGroup.DisplayName] = newGroup
 			group = newGroup
 		}
-
 		groupMembers, err := s.google.GetGroupMembers(g)
 		if err != nil {
+			log.WithField("group", g.Email).Warn("Error getting group members from Google")
 			return err
 		}
-
+		log.WithFields(Fields{
+			"group": g.Email,
+			"count": len(groupMembers),
+		}).Info("Group members retrieved from Google")
 		memberList := make(map[string]*admin.Member)
-
 		log.Info("Start group user sync")
-
 		for _, m := range groupMembers {
 			if _, ok := s.users[m.Email]; ok {
 				memberList[m.Email] = m
 			}
 		}
-
 		for _, u := range s.users {
 			log.WithField("user", u.Username).Debug("Checking user is in group already")
-			b, err := s.IsUserInGroup(u, group)
+			b, err := s.aws.IsUserInGroup(u, group)
 			if err != nil {
+				log.WithFields(Fields{
+					"user":  u.Username,
+					"group": group.DisplayName,
+				}).Warn("Error checking user membership in AWS group")
 				return err
 			}
-
 			if _, ok := memberList[u.Username]; ok {
-				if !*b {
-					log.WithField("user", u.Username).Info("Adding user to group")
-					_, err = s.identityStoreClient.CreateGroupMembership(
-						&identitystore.CreateGroupMembershipInput{
-							IdentityStoreId: &s.cfg.IdentityStoreID,
-							GroupId:         &group.ID,
-							MemberId:        &identitystore.MemberId{UserId: &u.ID},
-						},
-					)
+				if !b {
+					log.WithFields(Fields{
+						"user":  u.Username,
+						"group": group.DisplayName,
+					}).Info("Adding user to group")
+					err := s.aws.AddUserToGroup(u, group)
 					if err != nil {
+						log.WithFields(Fields{
+							"user":  u.Username,
+							"group": group.DisplayName,
+						}).Warn("Error adding user to group in AWS")
 						return err
 					}
+					log.WithFields(Fields{
+						"user":  u.Username,
+						"group": group.DisplayName,
+					}).Info("User added to group successfully in AWS")
 				}
 			} else {
-				if *b {
-					log.WithField("user", u.Username).Warn("Removing user from group")
-					err := s.RemoveUserFromGroup(&u.ID, &group.ID)
+				if b {
+					log.WithFields(Fields{
+						"user":  u.Username,
+						"group": group.DisplayName,
+					}).Warn("Removing user from group")
+					err := s.aws.RemoveUserFromGroup(u, group)
 					if err != nil {
+						log.WithFields(Fields{
+							"user":  u.Username,
+							"group": group.DisplayName,
+						}).Warn("Error removing user from group in AWS")
 						return err
 					}
+					log.WithFields(Fields{
+						"user":  u.Username,
+						"group": group.DisplayName,
+					}).Info("User removed from group successfully in AWS")
 				}
 			}
 		}
 	}
-
 	return nil
 }
 
@@ -270,70 +324,81 @@ func (s *syncGSuite) SyncGroups(query string) error {
 // References:
 // * https://developers.google.com/admin-sdk/directory/v1/guides/search-groups
 // query possible values:
-// '' --> empty or not defined
-//  name='contact'
-//  email:admin*
-//  memberKey=user@company.com
-//  name:contact* email:contact*
-//  name:Admin* email:aws-*
-//  email:aws-*
+// ” --> empty or not defined
+//
+//	name='contact'
+//	email:admin*
+//	memberKey=user@company.com
+//	name:contact* email:contact*
+//	name:Admin* email:aws-*
+//	email:aws-*
+//
 // process workflow:
-//  1) delete users in aws, these were deleted in google
-//  2) update users in aws, these were updated in google
-//  3) add users in aws, these were added in google
-//  4) add groups in aws and add its members, these were added in google
-//  5) validate equals aws an google groups members
-//  6) delete groups in aws, these were deleted in google
-func (s *syncGSuite) SyncGroupsUsers(queryGroups string, queryUsers string) error {
-
-	log.WithField("queryGroup", queryGroups).Info("get google groups")
-	log.WithField("queryUsers", queryUsers).Info("get google users")
-
-	log.Debug("preparing list of google users, groups and their members")
-	googleGroups, googleUsers, googleGroupsUsers, err := s.getGoogleGroupsAndUsers(queryGroups, queryUsers)
+//  1. delete users in aws, these were deleted in google
+//  2. update users in aws, these were updated in google
+//  3. add users in aws, these were added in google
+//  4. add groups in aws and add its members, these were added in google
+//  5. validate equals aws an google groups members
+//  6. delete groups in aws, these were deleted in google
+func (s *syncGSuite) SyncGroupsUsers(query string) error {
+	log.WithField("query", query).Info("get google groups")
+	googleGroups, err := s.google.GetGroups(query)
 	if err != nil {
+		log.WithField("query", query).Warn("Error getting Google groups")
 		return err
 	}
-
+	log.WithField("count", len(googleGroups)).Info("Google groups retrieved")
+	filteredGoogleGroups := []*admin.Group{}
+	for _, g := range googleGroups {
+		if s.ignoreGroup(g.Email) {
+			log.WithField("group", g.Email).Debug("ignoring group")
+			continue
+		}
+		filteredGoogleGroups = append(filteredGoogleGroups, g)
+	}
+	googleGroups = filteredGoogleGroups
+	log.Debug("preparing list of google users and then google groups and their members")
+	googleUsers, googleGroupsUsers, err := s.getGoogleGroupsAndUsers(googleGroups)
+	if err != nil {
+		log.Warn("Error getting Google groups and users")
+		return err
+	}
+	log.WithFields(log.Fields{
+		"googleUsers":  len(googleUsers),
+		"googleGroups": len(googleGroupsUsers),
+	}).Info("Google users and groups retrieved")
 	log.Info("get existing aws groups")
-	awsGroups, err := s.GetGroups()
+	awsGroups, err := s.aws.GetGroups()
 	if err != nil {
 		log.Error("error getting aws groups")
 		return err
 	}
-
+	log.WithField("count", len(awsGroups)).Info("AWS groups retrieved")
 	log.Info("get existing aws users")
-	awsUsers, err := s.GetUsers()
+	awsUsers, err := s.aws.GetUsers()
 	if err != nil {
 		log.Error("error getting aws users")
 		return err
 	}
-
-	log.Info("get active status for aws users")
-	for _, awsUser := range awsUsers {
-		scimUser, err := s.aws.FindUserByEmail(awsUser.Username)
-
-		if err != nil {
-			log.Error("error getting active status for user " + awsUser.ID)
-			return err
-		}
-
-		awsUser.Active = scimUser.Active
-	}
-
-	log.Info("preparing map of user id's to user")
-	awsUsersMap := CreateUserIDtoUserObjMap(awsUsers)
-
+	log.WithField("count", len(awsUsers)).Info("AWS users retrieved")
 	log.Debug("preparing list of aws groups and their members")
-	awsGroupsUsers, err := s.GetGroupMembershipsLists(awsGroups, awsUsersMap)
+	awsGroupsUsers, err := s.getAWSGroupsAndUsers(awsGroups, awsUsers)
 	if err != nil {
+		log.Warn("Error getting AWS groups and users")
 		return err
 	}
-
+	log.WithField("count", len(awsGroupsUsers)).Info("AWS groups and users retrieved")
 	// create list of changes by operations
 	addAWSUsers, delAWSUsers, updateAWSUsers, _ := getUserOperations(awsUsers, googleUsers)
 	addAWSGroups, delAWSGroups, equalAWSGroups := getGroupOperations(awsGroups, googleGroups)
-
+	log.WithFields(log.Fields{
+		"addAWSUsers":    len(addAWSUsers),
+		"delAWSUsers":    len(delAWSUsers),
+		"updateAWSUsers": len(updateAWSUsers),
+		"addAWSGroups":   len(addAWSGroups),
+		"delAWSGroups":   len(delAWSGroups),
+		"equalAWSGroups": len(equalAWSGroups),
+	}).Info("Changes to be applied")
 	log.Info("syncing changes")
 	// delete aws users (deleted in google)
 	log.Debug("deleting aws users deleted in google")
@@ -342,56 +407,42 @@ func (s *syncGSuite) SyncGroupsUsers(queryGroups string, queryUsers string) erro
 		return errors.New("deletion threshold exceeded for users")
 	}
 	for _, awsUser := range delAWSUsers {
-
 		log := log.WithFields(log.Fields{"user": awsUser.Username})
-
 		log.Debug("finding user")
 		awsUserFull, err := s.aws.FindUserByEmail(awsUser.Username)
 		if err != nil {
+			log.Warn("Error finding user in AWS")
 			return err
 		}
-
 		log.Warn("deleting user")
-		_, err = s.identityStoreClient.DeleteUser(
-			&identitystore.DeleteUserInput{IdentityStoreId: &s.cfg.IdentityStoreID, UserId: &awsUserFull.ID},
-		)
-		if err != nil {
+		if err := s.aws.DeleteUser(awsUserFull); err != nil {
 			log.Error("error deleting user")
 			return err
 		}
+		log.Info("User deleted successfully in AWS")
 	}
-
 	// update aws users (updated in google)
 	log.Debug("updating aws users updated in google")
 	for _, awsUser := range updateAWSUsers {
-
 		log := log.WithFields(log.Fields{"user": awsUser.Username})
-
 		log.Debug("finding user")
 		awsUserFull, err := s.aws.FindUserByEmail(awsUser.Username)
 		if err != nil {
+			log.Warn("Error finding user in AWS")
 			return err
 		}
-
 		log.Warn("updating user")
-		_, err = s.aws.UpdateUser(aws.UpdateUser(
-			awsUserFull.ID,
-			awsUser.Name.GivenName,
-			awsUser.Name.FamilyName,
-			awsUser.Username,
-			awsUser.Active))
+		_, err = s.aws.UpdateUser(awsUserFull)
 		if err != nil {
 			log.Error("error updating user")
 			return err
 		}
+		log.Info("User updated successfully in AWS")
 	}
-
 	// add aws users (added in google)
 	log.Debug("creating aws users added in google")
 	for _, awsUser := range addAWSUsers {
-
 		log := log.WithFields(log.Fields{"user": awsUser.Username})
-
 		log.Info("creating user")
 		_, err := s.aws.CreateUser(awsUser)
 		if err != nil {
@@ -403,95 +454,98 @@ func (s *syncGSuite) SyncGroupsUsers(queryGroups string, queryUsers string) erro
 			log.Error("error creating user")
 			return err
 		}
+		log.Info("User created successfully in AWS")
 	}
-
 	// add aws groups (added in google)
 	log.Debug("creating aws groups added in google")
 	for _, awsGroup := range addAWSGroups {
-
 		log := log.WithFields(log.Fields{"group": awsGroup.DisplayName})
-
 		log.Info("creating group")
-		newAwsGroup, err := s.identityStoreClient.CreateGroup(
-			&identitystore.CreateGroupInput{IdentityStoreId: &s.cfg.IdentityStoreID, DisplayName: &awsGroup.DisplayName},
-		)
+		_, err := s.aws.CreateGroup(awsGroup)
 		if err != nil {
 			log.Error("creating group")
 			return err
 		}
-
+		log.Info("Group created successfully in AWS")
 		// add members of the new group
 		for _, googleUser := range googleGroupsUsers[awsGroup.DisplayName] {
-
 			// equivalent aws user of google user on the fly
 			log.Debug("finding user")
 			awsUserFull, err := s.aws.FindUserByEmail(googleUser.PrimaryEmail)
 			if err != nil {
+				log.WithField("email", googleUser.PrimaryEmail).Warn("Error finding user in AWS")
 				return err
 			}
-
 			log.WithField("user", awsUserFull.Username).Info("adding user to group")
-			_, err = s.identityStoreClient.CreateGroupMembership(
-				&identitystore.CreateGroupMembershipInput{
-					IdentityStoreId: &s.cfg.IdentityStoreID,
-					GroupId:         newAwsGroup.GroupId,
-					MemberId:        &identitystore.MemberId{UserId: &awsUserFull.ID},
-				},
-			)
+			err = s.aws.AddUserToGroup(awsUserFull, awsGroup)
 			if err != nil {
+				log.WithFields(Fields{
+					"user":  awsUserFull.Username,
+					"group": awsGroup.DisplayName,
+				}).Warn("Error adding user to group in AWS")
 				return err
 			}
+			log.WithFields(Fields{
+				"user":  awsUserFull.Username,
+				"group": awsGroup.DisplayName,
+			}).Info("User added to group successfully in AWS")
 		}
 	}
-
 	// list of users to to be removed in aws groups
 	deleteUsersFromGroup, _ := getGroupUsersOperations(googleGroupsUsers, awsGroupsUsers)
-
 	// validate groups members are equal in aws and google
 	log.Debug("validating groups members, equals in aws and google")
 	for _, awsGroup := range equalAWSGroups {
-
 		// add members of the new group
 		log := log.WithFields(log.Fields{"group": awsGroup.DisplayName})
-
 		for _, googleUser := range googleGroupsUsers[awsGroup.DisplayName] {
-
 			log.WithField("user", googleUser.PrimaryEmail).Debug("finding user")
 			awsUserFull, err := s.aws.FindUserByEmail(googleUser.PrimaryEmail)
 			if err != nil {
+				log.WithField("email", googleUser.PrimaryEmail).Warn("Error finding user in AWS")
 				return err
 			}
-
 			log.WithField("user", awsUserFull.Username).Debug("checking user is in group already")
-			b, err := s.IsUserInGroup(awsUserFull, awsGroup)
+			b, err := s.aws.IsUserInGroup(awsUserFull, awsGroup)
 			if err != nil {
+				log.WithFields(Fields{
+					"user":  awsUserFull.Username,
+					"group": awsGroup.DisplayName,
+				}).Warn("Error checking user membership in AWS group")
 				return err
 			}
-
-			if !*b {
+			if !b {
 				log.WithField("user", awsUserFull.Username).Info("adding user to group")
-				_, err = s.identityStoreClient.CreateGroupMembership(
-					&identitystore.CreateGroupMembershipInput{
-						IdentityStoreId: &s.cfg.IdentityStoreID,
-						GroupId:         &awsGroup.ID,
-						MemberId:        &identitystore.MemberId{UserId: &awsUserFull.ID},
-					},
-				)
+				err := s.aws.AddUserToGroup(awsUserFull, awsGroup)
 				if err != nil {
+					log.WithFields(Fields{
+						"user":  awsUserFull.Username,
+						"group": awsGroup.DisplayName,
+					}).Warn("Error adding user to group in AWS")
 					return err
 				}
+				log.WithFields(Fields{
+					"user":  awsUserFull.Username,
+					"group": awsGroup.DisplayName,
+				}).Info("User added to group successfully in AWS")
 			}
 		}
-
 		for _, awsUser := range deleteUsersFromGroup[awsGroup.DisplayName] {
 			log.WithField("user", awsUser.Username).Warn("removing user from group")
-			err := s.RemoveUserFromGroup(&awsUser.ID, &awsGroup.ID)
+			err := s.aws.RemoveUserFromGroup(awsUser, awsGroup)
 			if err != nil {
+				log.WithFields(Fields{
+					"user":  awsUser.Username,
+					"group": awsGroup.DisplayName,
+				}).Warn("Error removing user from group in AWS")
 				return err
 			}
+			log.WithFields(Fields{
+				"user":  awsUser.Username,
+				"group": awsGroup.DisplayName,
+			}).Info("User removed from group successfully in AWS")
 		}
 	}
-
 	// delete aws groups (deleted in google)
 	log.Debug("delete aws groups deleted in google")
 	if !checkGroupDeletionThreshold(delAWSGroups) {
@@ -499,204 +553,239 @@ func (s *syncGSuite) SyncGroupsUsers(queryGroups string, queryUsers string) erro
 		return errors.New("deletion threshold exceeded for groups")
 	}
 	for _, awsGroup := range delAWSGroups {
-
 		log := log.WithFields(log.Fields{"group": awsGroup.DisplayName})
-
 		log.Debug("finding group")
 		awsGroupFull, err := s.aws.FindGroupByDisplayName(awsGroup.DisplayName)
 		if err != nil {
+			log.WithField("group", awsGroup.DisplayName).Warn("Error finding group in AWS")
 			return err
 		}
-
 		log.Warn("deleting group")
-		_, err = s.identityStoreClient.DeleteGroup(
-			&identitystore.DeleteGroupInput{IdentityStoreId: &s.cfg.IdentityStoreID, GroupId: &awsGroupFull.ID},
-		)
+		err = s.aws.DeleteGroup(awsGroupFull)
 		if err != nil {
 			log.Error("deleting group")
 			return err
 		}
+		log.Info("Group deleted successfully in AWS")
 	}
-
 	log.Info("sync completed")
-
 	return nil
 }
 
 // getGoogleGroupsAndUsers return a list of google users members of googleGroups
 // and a map of google groups and its users' list
-func (s *syncGSuite) getGoogleGroupsAndUsers(queryGroups string, queryUsers string) ([]*admin.Group, []*admin.User, map[string][]*admin.User, error) {
+func (s *syncGSuite) getGoogleGroupsAndUsers(googleGroups []*admin.Group) ([]*admin.User, map[string][]*admin.User, error) {
+	log.WithField("count", len(googleGroups)).Info("Getting Google groups and users")
 	gUsers := make([]*admin.User, 0)
 	gGroupsUsers := make(map[string][]*admin.User)
-        gUserDetailCache := make(map[string]*admin.User)
-        gGroupDetailCache := make(map[string]*admin.Group)
 	gUniqUsers := make(map[string]*admin.User)
-
-        // For large directories this will reduce execution time and avoid throttling limits
-        log.Debug("Fetching ALL users from google, to use as cache")
-	googleUsers, err := s.google.GetUsers("*")
-        if err != nil {
-                return nil, nil, nil, err
-        }
-        for _, u := range googleUsers {
-                gUserDetailCache[u.PrimaryEmail] = u
-        }
-
-        log.Debug("Fetching ALL groups from google, to use as cache")
-	googleGroups, err := s.google.GetGroups("*")
-        if err != nil {
-                return nil, nil, nil, err
-        }
-        for _, g := range googleGroups {
-                gGroupDetailCache[g.Email] = g
-        }
-
-	// Fetch Users
-        log.Debug("get users from google, based on UserMatch,  regardless of group membership")
-        googleUsers, err = s.google.GetUsers(queryUsers)
-        if err != nil {
-                return nil, nil, nil, err
-        }
-
-        log.Debug("process users from google, filtering as required")
-	for _, u := range googleUsers {
-		log.WithField("email", u.PrimaryEmail).Debug("processing member")
-
-                // Remove any users that should be ignored
-		if s.ignoreUser(u.PrimaryEmail) {
-                	log.WithField("id", u.PrimaryEmail).Debug("ignoring user")
-			continue
-		}
-                _, ok := gUniqUsers[u.PrimaryEmail]
-                if !ok {
-                	log.WithField("id", u.PrimaryEmail).Debug("adding user")
-                	gUniqUsers[u.PrimaryEmail] = u
-                }
-
-        }
-
-	log.Debug("get groups from google")
-        gGroups, err := s.google.GetGroups(queryGroups)
-        if err != nil {
-                return nil, nil, nil, err
-        }
-        filteredGoogleGroups := []*admin.Group{}
-        for _, g := range gGroups {
-                if s.ignoreGroup(g.Email) {
-                        log.WithField("group", g.Email).Debug("ignoring group")
-                        continue
-                }
-                filteredGoogleGroups = append(filteredGoogleGroups, g)
-        }
-        gGroups = filteredGoogleGroups
-
-        log.Debug("for each group retrieve the group members")
-	for _, g := range gGroups {
-
+	for _, g := range googleGroups {
 		log := log.WithFields(log.Fields{"group": g.Name})
-
 		if s.ignoreGroup(g.Email) {
 			log.Debug("ignoring group")
 			continue
 		}
-
 		log.Debug("get group members from google")
-		membersUsers := s.getGoogleUsersInGroup(g, gUserDetailCache, gGroupDetailCache)
-
-		// If we've not seen the user email address before add it to the list of unique users
-                for _, m := range membersUsers {
-			_, ok := gUniqUsers[m.PrimaryEmail]
+		groupMembers, err := s.google.GetGroupMembers(g)
+		if err != nil {
+			log.WithField("group", g.Email).Warn("Error getting group members from Google")
+			return nil, nil, err
+		}
+		log.WithField("count", len(groupMembers)).Info("Group members retrieved from Google")
+		log.Debug("get users")
+		membersUsers := make([]*admin.User, 0)
+		for _, m := range groupMembers {
+			if s.ignoreUser(m.Email) {
+				log.WithField("id", m.Email).Debug("ignoring user")
+				continue
+			}
+			if m.Type == "GROUP" {
+				log.WithField("id", m.Email).Debug("ignoring group address")
+				continue
+			}
+			log.WithField("id", m.Email).Debug("get user")
+			q := fmt.Sprintf("email:%s", m.Email)
+			u, err := s.google.GetUsers(q) // TODO: implement GetUser(m.Email)
+			if err != nil {
+				log.WithField("email", m.Email).Warn("Error getting user from Google")
+				return nil, nil, err
+			}
+			if len(u) == 0 {
+				log.WithField("email", m.Email).Debug("Ignoring Unknown User")
+				continue
+			}
+			log.WithFields(Fields{
+				"email":      u[0].PrimaryEmail,
+				"givenName":  u[0].Name.GivenName,
+				"familyName": u[0].Name.FamilyName,
+			}).Info("User retrieved from Google")
+			membersUsers = append(membersUsers, u[0])
+			_, ok := gUniqUsers[m.Email]
 			if !ok {
-				gUniqUsers[m.PrimaryEmail] = gUserDetailCache[m.PrimaryEmail]
+				gUniqUsers[m.Email] = u[0]
 			}
 		}
 		gGroupsUsers[g.Name] = membersUsers
+		log.WithFields(Fields{
+			"group": g.Name,
+			"count": len(membersUsers),
+		}).Info("Group members added to map")
 	}
-
 	for _, user := range gUniqUsers {
 		gUsers = append(gUsers, user)
 	}
+	log.WithFields(log.Fields{
+		"uniqueUsers": len(gUniqUsers),
+		"totalUsers":  len(gUsers),
+	}).Info("Google users retrieved")
+	return gUsers, gGroupsUsers, nil
+}
 
-	return gGroups, gUsers, gGroupsUsers, nil
+// getAWSGroupsAndUsers return a list of google users members of googleGroups
+// and a map of google groups and its users' list
+func (s *syncGSuite) getAWSGroupsAndUsers(awsGroups []*aws.Group, awsUsers []*aws.User) (map[string][]*aws.User, error) {
+	log.WithFields(log.Fields{
+		"groups": len(awsGroups),
+		"users":  len(awsUsers),
+	}).Info("Getting AWS groups and users")
+	awsGroupsUsers := make(map[string][]*aws.User)
+	for _, awsGroup := range awsGroups {
+		users := make([]*aws.User, 0)
+		log := log.WithFields(log.Fields{"group": awsGroup.DisplayName})
+		log.Debug("get group members from aws")
+		// NOTE: AWS has not implemented yet some method to get the groups members https://docs.aws.amazon.com/singlesignon/latest/developerguide/listgroups.html
+		// so, we need to check each user in each group which are too many unnecessary API calls
+		for _, user := range awsUsers {
+			log.Debug("checking if user is member of")
+			found, err := s.aws.IsUserInGroup(user, awsGroup)
+			if err != nil {
+				log.WithFields(Fields{
+					"user":  user.Username,
+					"group": awsGroup.DisplayName,
+				}).Warn("Error checking user membership in AWS group")
+				return nil, err
+			}
+			if found {
+				users = append(users, user)
+				log.WithField("user", user.Username).Debug("User is a member of the group")
+			}
+		}
+		awsGroupsUsers[awsGroup.DisplayName] = users
+		log.WithField("count", len(users)).Info("Group members added to map")
+	}
+	log.WithField("count", len(awsGroupsUsers)).Info("AWS groups and users retrieved")
+	return awsGroupsUsers, nil
 }
 
 // getGroupOperations returns the groups of AWS that must be added, deleted and are equals
 func getGroupOperations(awsGroups []*aws.Group, googleGroups []*admin.Group) (add []*aws.Group, delete []*aws.Group, equals []*aws.Group) {
-
+	log.WithFields(log.Fields{
+		"awsGroups":    len(awsGroups),
+		"googleGroups": len(googleGroups),
+	}).Info("Getting group operations")
 	awsMap := make(map[string]*aws.Group)
 	googleMap := make(map[string]struct{})
-
 	for _, awsGroup := range awsGroups {
 		awsMap[awsGroup.DisplayName] = awsGroup
 	}
-
 	for _, gGroup := range googleGroups {
 		googleMap[gGroup.Name] = struct{}{}
 	}
-
 	// AWS Groups found and not found in google
 	for _, gGroup := range googleGroups {
 		if _, found := awsMap[gGroup.Name]; found {
+			log.WithField("group", gGroup.Name).Debug("Group found in AWS and Google")
 			equals = append(equals, awsMap[gGroup.Name])
 		} else {
+			log.WithField("group", gGroup.Name).Info("Group not found in AWS, will be added")
 			add = append(add, aws.NewGroup(gGroup.Name))
 		}
 	}
-
 	// Google Groups founds and not in aws
 	for _, awsGroup := range awsGroups {
 		if _, found := googleMap[awsGroup.DisplayName]; !found {
+			log.WithField("group", awsGroup.DisplayName).Info("Group not found in Google, will be deleted from AWS")
 			delete = append(delete, aws.NewGroup(awsGroup.DisplayName))
 		}
 	}
-
+	log.WithFields(log.Fields{
+		"add":    len(add),
+		"delete": len(delete),
+		"equals": len(equals),
+	}).Info("Group operations determined")
 	return add, delete, equals
 }
 
 // getUserOperations returns the users of AWS that must be added, deleted, updated and are equals
 func getUserOperations(awsUsers []*aws.User, googleUsers []*admin.User) (add []*aws.User, delete []*aws.User, update []*aws.User, equals []*aws.User) {
-
+	log.WithFields(log.Fields{
+		"awsUsers":    len(awsUsers),
+		"googleUsers": len(googleUsers),
+	}).Info("Getting user operations")
 	awsMap := make(map[string]*aws.User)
 	googleMap := make(map[string]struct{})
-
 	for _, awsUser := range awsUsers {
 		awsMap[awsUser.Username] = awsUser
 	}
-
 	for _, gUser := range googleUsers {
 		googleMap[gUser.PrimaryEmail] = struct{}{}
 	}
-
 	// AWS Users found and not found in google
 	for _, gUser := range googleUsers {
 		if awsUser, found := awsMap[gUser.PrimaryEmail]; found {
+			log.WithField("user", gUser.PrimaryEmail).Debug("User found in AWS and Google")
 			if awsUser.Active == gUser.Suspended ||
 				awsUser.Name.GivenName != gUser.Name.GivenName ||
 				awsUser.Name.FamilyName != gUser.Name.FamilyName {
+				log.WithFields(log.Fields{
+					"user":       gUser.PrimaryEmail,
+					"givenName":  gUser.Name.GivenName,
+					"familyName": gUser.Name.FamilyName,
+					"suspended":  gUser.Suspended,
+				}).Info("User attributes mismatch, will be updated in AWS")
 				update = append(update, aws.NewUser(gUser.Name.GivenName, gUser.Name.FamilyName, gUser.PrimaryEmail, !gUser.Suspended))
 			} else {
+				log.WithField("user", gUser.PrimaryEmail).Debug("User attributes match in AWS and Google")
 				equals = append(equals, awsUser)
 			}
 		} else {
+			log.WithFields(log.Fields{
+				"user":       gUser.PrimaryEmail,
+				"givenName":  gUser.Name.GivenName,
+				"familyName": gUser.Name.FamilyName,
+				"suspended":  gUser.Suspended,
+			}).Info("User not found in AWS, will be added")
 			add = append(add, aws.NewUser(gUser.Name.GivenName, gUser.Name.FamilyName, gUser.PrimaryEmail, !gUser.Suspended))
 		}
 	}
-
 	// Google Users founds and not in aws
 	for _, awsUser := range awsUsers {
 		if _, found := googleMap[awsUser.Username]; !found {
+			log.WithFields(log.Fields{
+				"user":       awsUser.Username,
+				"givenName":  awsUser.Name.GivenName,
+				"familyName": awsUser.Name.FamilyName,
+				"active":     awsUser.Active,
+			}).Info("User not found in Google, will be deleted from AWS")
 			delete = append(delete, aws.NewUser(awsUser.Name.GivenName, awsUser.Name.FamilyName, awsUser.Username, awsUser.Active))
 		}
 	}
-
+	log.WithFields(log.Fields{
+		"add":    len(add),
+		"delete": len(delete),
+		"update": len(update),
+		"equals": len(equals),
+	}).Info("User operations determined")
 	return add, delete, update, equals
 }
 
 // groupUsersOperations returns the groups and its users of AWS that must be delete from these groups and what are equals
 func getGroupUsersOperations(gGroupsUsers map[string][]*admin.User, awsGroupsUsers map[string][]*aws.User) (delete map[string][]*aws.User, equals map[string][]*aws.User) {
-
+	log.WithFields(log.Fields{
+		"googleGroups": len(gGroupsUsers),
+		"awsGroups":    len(awsGroupsUsers),
+	}).Info("Getting group users operations")
 	mbG := make(map[string]map[string]struct{})
-
 	// get user in google groups that are in aws groups and
 	// users in aws groups that aren't in google groups
 	for gGroupName, gGroupUsers := range gGroupsUsers {
@@ -705,116 +794,96 @@ func getGroupUsersOperations(gGroupsUsers map[string][]*admin.User, awsGroupsUse
 			mbG[gGroupName][gUser.PrimaryEmail] = struct{}{}
 		}
 	}
-
 	delete = make(map[string][]*aws.User)
 	equals = make(map[string][]*aws.User)
 	for awsGroupName, awsGroupUsers := range awsGroupsUsers {
 		for _, awsUser := range awsGroupUsers {
 			// users that exist in aws groups but doesn't in google groups
 			if _, found := mbG[awsGroupName][awsUser.Username]; found {
+				log.WithFields(log.Fields{
+					"user":  awsUser.Username,
+					"group": awsGroupName,
+				}).Debug("User found in AWS group and Google group")
 				equals[awsGroupName] = append(equals[awsGroupName], awsUser)
 			} else {
+				log.WithFields(log.Fields{
+					"user":  awsUser.Username,
+					"group": awsGroupName,
+				}).Info("User found in AWS group but not in Google group, will be removed from AWS group")
 				delete[awsGroupName] = append(delete[awsGroupName], awsUser)
 			}
 		}
 	}
-
+	log.WithFields(log.Fields{
+		"delete": len(delete),
+		"equals": len(equals),
+	}).Info("Group users operations determined")
 	return
 }
 
 // DoSync will create a logger and run the sync with the paths
 // given to do the sync.
 func DoSync(ctx context.Context, cfg *config.Config) error {
+	log.Info("Starting synchronization process")
 	log.Info("Syncing AWS users and groups from Google Workspace SAML Application")
-
 	creds := []byte(cfg.GoogleCredentials)
-
 	if !cfg.IsLambda {
 		b, err := ioutil.ReadFile(cfg.GoogleCredentials)
 		if err != nil {
+			log.WithError(err).Error("Error reading Google credentials file")
 			return err
 		}
 		creds = b
 	}
-
 	// create a http client with retry and backoff capabilities
 	retryClient := retryablehttp.NewClient()
-
 	// https://github.com/hashicorp/go-retryablehttp/issues/6
 	if cfg.Debug {
 		retryClient.Logger = log.StandardLogger()
 	} else {
 		retryClient.Logger = nil
 	}
-
 	httpClient := retryClient.StandardClient()
-
-	googleClient, err := google.NewClient(ctx, cfg.GoogleAdmin, creds)
+	googleClient, err := google.NewClient(ctx, cfg.GoogleAdmin, creds, cfg.GoogleCustomerId)
 	if err != nil {
-	        log.WithField("error", err).Warn("Problem establising a connection to Google directory")
+		log.WithError(err).Error("Error creating Google client")
 		return err
 	}
-
-	awsScimClient, err := aws.NewClient(
+	log.Info("Google client created successfully")
+	awsClient, err := aws.NewClient(
 		httpClient,
 		&aws.Config{
 			Endpoint: cfg.SCIMEndpoint,
 			Token:    cfg.SCIMAccessToken,
 		})
 	if err != nil {
-	        log.WithField("error", err).Warn("Problem establising a SCIM connection to AWS IAM Identity Center")
+		log.WithError(err).Error("Error creating AWS client")
 		return err
 	}
-
-	// Initialize AWS session
-	sess, err := aws_sdk_sess.NewSession(&aws_sdk.Config{
-		// AWS Region to send requests to, provided by config
-		Region: &cfg.Region,
-	})
-
-	if err != nil {
-	        log.WithField("error", err).Warn("Problem establising a session for Identity Store")
-		return err
-	}
-
-	// Initialize AWS Identity Store Public API Client with session
-	identityStoreClient := identitystore.New(sess)
-
-	response, err := identityStoreClient.ListGroups(
-                &identitystore.ListGroupsInput{IdentityStoreId: &cfg.IdentityStoreID})
-
-	if err != nil {
-	        log.WithField("error", err).Warn("Problem performing test query against Identity Store")
-		return err
-	} else {
-	        log.WithField("Groups", response).Info("Test call for groups successful")
-                
-        }
-
-	// Initialize sync client with
-	// 1. SCIM API client
-	// 2. Google Directory API client
-	// 3. Identity Store Public API client
-	c := New(cfg, awsScimClient, googleClient, identityStoreClient)
-
-	log.WithField("sync_method", cfg.SyncMethod).Info("syncing")
+	log.Info("AWS client created successfully")
+	c := New(cfg, awsClient, googleClient)
+	log.WithField("sync_method", cfg.SyncMethod).Info("Starting synchronization")
 	if cfg.SyncMethod == config.DefaultSyncMethod {
-		err = c.SyncGroupsUsers(cfg.GroupMatch, cfg.UserMatch)
+		log.Info("Using default synchronization method")
+		err = c.SyncGroupsUsers(cfg.GroupMatch)
 		if err != nil {
+			log.WithError(err).Error("Error synchronizing groups and users")
 			return err
 		}
 	} else {
+		log.Info("Using alternative synchronization method")
 		err = c.SyncUsers(cfg.UserMatch)
 		if err != nil {
+			log.WithError(err).Error("Error synchronizing users")
 			return err
 		}
-
 		err = c.SyncGroups(cfg.GroupMatch)
 		if err != nil {
+			log.WithError(err).Error("Error synchronizing groups")
 			return err
 		}
 	}
-
+	log.Info("Synchronization completed successfully")
 	return nil
 }
 
@@ -846,259 +915,6 @@ func (s *syncGSuite) includeGroup(name string) bool {
 	}
 
 	return false
-}
-
-var awsGroups []*aws.Group
-
-func (s *syncGSuite) GetGroups() ([]*aws.Group, error) {
-	awsGroups = make([]*aws.Group, 0)
-
-	err := s.identityStoreClient.ListGroupsPages(
-		&identitystore.ListGroupsInput{IdentityStoreId: &s.cfg.IdentityStoreID},
-		ListGroupsPagesCallbackFn,
-	)
-
-	if err != nil {
-		return nil, err
-	}
-
-	return awsGroups, nil
-}
-
-func ListGroupsPagesCallbackFn(page *identitystore.ListGroupsOutput, lastPage bool) bool {
-	// Loop through each Group returned
-	for _, group := range page.Groups {
-		// Convert to native Group object
-		awsGroups = append(awsGroups, &aws.Group{
-			ID:          *group.GroupId,
-			Schemas:     []string{"urn:ietf:params:scim:schemas:core:2.0:Group"},
-			DisplayName: *group.DisplayName,
-			Members:     []string{},
-		})
-	}
-
-	return !lastPage
-}
-
-var awsUsers []*aws.User
-
-func (s *syncGSuite) GetUsers() ([]*aws.User, error) {
-	awsUsers = make([]*aws.User, 0)
-
-	err := s.identityStoreClient.ListUsersPages(
-		&identitystore.ListUsersInput{IdentityStoreId: &s.cfg.IdentityStoreID},
-		ListUsersPagesCallbackFn,
-	)
-
-	if err != nil {
-		return nil, err
-	}
-
-	return awsUsers, nil
-}
-
-func ListUsersPagesCallbackFn(page *identitystore.ListUsersOutput, lastPage bool) bool {
-	// Loop through each User in ListUsersOutput and convert to native User object
-	for _, user := range page.Users {
-		awsUsers = append(awsUsers, ConvertSdkUserObjToNative(user))
-	}
-	return !lastPage
-}
-
-func ConvertSdkUserObjToNative(user *identitystore.User) *aws.User {
-	// Convert emails into native Email object
-	userEmails := make([]aws.UserEmail, 0)
-
-	for _, email := range user.Emails {
-		if email.Value == nil || email.Type == nil || email.Primary == nil {
-              		// This must be a user created by AWS Control Tower
-                        // Need feature development to make how these users are treated
-			// configurable.
-			continue
-		}
-		userEmails = append(userEmails, aws.UserEmail{
-			Value:   *email.Value,
-			Type:    *email.Type,
-			Primary: *email.Primary,
-		})
-	}
-
-	// Convert addresses into native Address object
-	userAddresses := make([]aws.UserAddress, 0)
-
-	for _, address := range user.Addresses {
-		userAddresses = append(userAddresses, aws.UserAddress{
-			Type: *address.Type,
-		})
-	}
-
-	return &aws.User{
-		ID:       *user.UserId,
-		Schemas:  []string{"urn:ietf:params:scim:schemas:core:2.0:User"},
-		Username: *user.UserName,
-		Name: struct {
-			FamilyName string `json:"familyName"`
-			GivenName  string `json:"givenName"`
-		}{
-			FamilyName: *user.Name.FamilyName,
-			GivenName:  *user.Name.GivenName,
-		},
-		DisplayName: *user.DisplayName,
-		Emails:      userEmails,
-		Addresses:   userAddresses,
-	}
-}
-
-func CreateUserIDtoUserObjMap(awsUsers []*aws.User) map[string]*aws.User {
-	awsUsersMap := make(map[string]*aws.User)
-
-	for _, awsUser := range awsUsers {
-		awsUsersMap[awsUser.ID] = awsUser
-	}
-
-	return awsUsersMap
-}
-
-var ListGroupMembershipPagesCallbackFn func(page *identitystore.ListGroupMembershipsOutput, lastPage bool) bool
-
-func (s *syncGSuite) GetGroupMembershipsLists(awsGroups []*aws.Group, awsUsersMap map[string]*aws.User) (map[string][]*aws.User, error) {
-	awsGroupsUsers := make(map[string][]*aws.User)
-	curGroup := &aws.Group{}
-
-	ListGroupMembershipPagesCallbackFn = func(page *identitystore.ListGroupMembershipsOutput, lastPage bool) bool {
-		for _, member := range page.GroupMemberships { // For every member in the group
-			userId := member.MemberId.UserId
-			user := awsUsersMap[*userId]
-
-			// Append new user onto existing list of users
-			awsGroupsUsers[curGroup.DisplayName] = append(awsGroupsUsers[curGroup.DisplayName], user)
-		}
-
-		return !lastPage
-	}
-
-	// For every group, get the members and assign in awsGroupsUsers map
-	for _, group := range awsGroups {
-		curGroup = group
-		awsGroupsUsers[curGroup.DisplayName] = make([]*aws.User, 0)
-
-		// Get User ID of every member in group
-		err := s.identityStoreClient.ListGroupMembershipsPages(
-			&identitystore.ListGroupMembershipsInput{
-				IdentityStoreId: &s.cfg.IdentityStoreID,
-				GroupId:         &group.ID,
-			}, ListGroupMembershipPagesCallbackFn)
-
-		if err != nil {
-			return nil, err
-		}
-	}
-
-	return awsGroupsUsers, nil
-}
-
-func (s *syncGSuite) IsUserInGroup(user *aws.User, group *aws.Group) (*bool, error) {
-	isUserInGroupOutput, err := s.identityStoreClient.IsMemberInGroups(
-		&identitystore.IsMemberInGroupsInput{
-			IdentityStoreId: &s.cfg.IdentityStoreID,
-			GroupIds:        []*string{&group.ID},
-			MemberId:        &identitystore.MemberId{UserId: &user.ID},
-		},
-	)
-
-	if err != nil {
-		return nil, err
-	}
-
-	isUserInGroup := isUserInGroupOutput.Results[0].MembershipExists
-
-	return isUserInGroup, nil
-}
-
-func (s *syncGSuite) RemoveUserFromGroup(userId *string, groupId *string) error {
-	memberIdOutput, err := s.identityStoreClient.GetGroupMembershipId(
-		&identitystore.GetGroupMembershipIdInput{
-			IdentityStoreId: &s.cfg.IdentityStoreID,
-			GroupId:         groupId,
-			MemberId:        &identitystore.MemberId{UserId: userId},
-		},
-	)
-
-	if err != nil {
-		return err
-	}
-
-	memberId := memberIdOutput.MembershipId
-
-	_, err = s.identityStoreClient.DeleteGroupMembership(
-		&identitystore.DeleteGroupMembershipInput{
-			IdentityStoreId: &s.cfg.IdentityStoreID,
-			MembershipId:    memberId,
-		},
-	)
-
-	if err != nil {
-		return err
-	}
-
-	return nil
-}
-
-func (s *syncGSuite) getGoogleUsersInGroup(group *admin.Group, userCache map[string]*admin.User, groupCache map[string]*admin.Group) []*admin.User {
-	log.WithField("Email:", group.Email).Debug("getGoogleGroupMembers()")
-
-	 // retrieve the members of the group
-	groupMembers, err := s.google.GetGroupMembers(group)
-	if err != nil {
-		return nil
-	}
-        membersUsers := make([]*admin.User, 0)
-
-	// process the members of the group
-        for _, m := range groupMembers {
-        	log.WithField("email", m.Email).Debug("processing member")
-                // Ignore Owners aren't relevant in Identity Store
-		// so are treated as group members.
-                if m.Role == "OWNER" {
-                	log.WithField("id", m.Email).Debug("owner role")
-                }
-
-                // Ignore any external members, since they don't have users
-                // that can be synced
-                if m.Type == "USER" && m.Status != "ACTIVE" {
-                        log.WithField("id", m.Email).Warn("ignoring external user")
-                        continue
-                }
-
-                // handle nested groups, by adding their membership to the end
-                // of googleMembers
-                if m.Type == "GROUP" {
-		    	log.WithField("Email:", m.Email).Debug("calling getGoogleGroupMembers() for nested group")
-			_, found := groupCache[m.Email]
-			if found {
-                        	membersUsers = append (membersUsers, s.getGoogleUsersInGroup(groupCache[m.Email], userCache, groupCache)...)
-			} else {
-                        	log.WithField("id", m.Email).Warn("missing nested group")
-			}
-                        continue
-                }
-                // Remove any users that should be ignored
-                if s.ignoreUser(m.Email) {
-                        log.WithField("id", m.Email).Debug("ignoring user")
-                        continue
-                }
-
-                // Find the group member in the cache of UserDetails
-                _, found := userCache[m.Email]
-                if found {
-                        membersUsers = append(membersUsers, userCache[m.Email])
-                } else {
-                        log.WithField("id", m.Email).Warn("missing user")
-                        continue
-                }
-        }
-
-        return membersUsers
 }
 
 // checkUserDeletionThreshold checks if the number of users to be deleted exceeds the threshold.


### PR DESCRIPTION
https://healxltd.atlassian.net/jira/software/projects/ENT/boards/105?selectedIssue=ENT-421

This PR introduces new functionality to the `ssosync` tool to prevent accidental large-scale deletions of users and groups. We've added two functions, `checkUserDeletionThreshold` and `checkGroupDeletionThreshold`, which enforce a maximum threshold for deletions per operation. The threshold is set at 4 deletions. If a deletion operation exceeds this number, the operation is halted, and a warning is logged. This update aims to enhance the robustness of our user and group synchronization process by adding a safeguard against potential sync issues or misconfigurations.

**Changes:**
1. Added `checkUserDeletionThreshold` function to limit user deletions.
2. Added `checkGroupDeletionThreshold` function to limit group deletions.
3. Integrated these functions into the existing deletion workflows to check the threshold before proceeding with deletions.


